### PR TITLE
Update to Document Engine 1.11.0 and bump chart version to 5.2.0

### DIFF
--- a/charts/document-engine/CHANGELOG.md
+++ b/charts/document-engine/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [5.2.0 (2025-07-24)](#513-2025-08-25)
+    - [Changed](#changed)
   - [5.1.3 (2025-07-24)](#513-2025-07-24)
     - [Changed](#changed)
   - [5.1.2 (2025-07-16)](#512-2025-07-16)
@@ -146,6 +148,12 @@
     - [Changed](#changed-40)
   - [2.0.0](#200)
     - [Changed](#changed-41)
+
+## 5.2.0 (2025-08-25)
+
+### Changed
+
+* [Document Engine 1.11.0](https://www.nutrient.io/guides/document-engine/release-notes/changelog/#1.11.0)
 
 ## 5.1.3 (2025-07-24)
 

--- a/charts/document-engine/Chart.yaml
+++ b/charts/document-engine/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 description: Document Engine is a backend software for processing documents and powering automation workflows.
 home: https://www.nutrient.io/sdk/document-engine
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 5.1.3
-appVersion: "1.10.1"
+version: 5.2.0
+appVersion: "1.11.0"
 
 keywords:
   - nutrient

--- a/charts/document-engine/README.md
+++ b/charts/document-engine/README.md
@@ -1,6 +1,6 @@
 # Document Engine Helm chart
 
-![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
+![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
 
 Document Engine is a backend software for processing documents and powering automation workflows.
 


### PR DESCRIPTION
Update to Document Engine 1.11.0 and bump chart version to 5.2.0.

https://nutrient.atlassian.net/browse/SERVER-1971