### PR TITLE
document-engine: fix migration Job secretRefs for inline creds; correct Azure secret name; clarify Redis ttlSeconds units

### DIFF
--- a/charts/document-engine/templates/_helpers.tpl
+++ b/charts/document-engine/templates/_helpers.tpl
@@ -186,7 +186,7 @@ Object storage parameters
 
 {{- define "document-engine.storage.azure.secret.name" -}}
   {{- if (eq (include "document-engine.storage.azure.createSecret" .) "true") -}}
-    {{- printf "%s-s3" (include "document-engine.fullname" .) -}}
+    {{- printf "%s-azure" (include "document-engine.fullname" .) -}}
   {{- else -}}
     {{- .Values.assetStorage.azure.externalSecretName -}}
   {{- end -}}

--- a/charts/document-engine/templates/storage/storage-migration.Job.yaml
+++ b/charts/document-engine/templates/storage/storage-migration.Job.yaml
@@ -51,13 +51,13 @@ spec:
                 name: {{ .Values.database.postgres.externalAdminSecretName }}
           {{- end }}
 
-          {{- if .Values.assetStorage.redis.enabled }}
+          {{- if and .Values.assetStorage.redis.enabled .Values.assetStorage.redis.externalSecretName }}
             - secretRef:
-                name: {{ include "document-engine.storage.redis.secret.name" . }}
+                name: {{ .Values.assetStorage.redis.externalSecretName }}
           {{- end }}
-          {{- if eq (include "document-engine.storage.s3.enabled" .) "true" }}
+          {{- if and (eq (include "document-engine.storage.s3.enabled" .) "true") .Values.assetStorage.s3.externalSecretName }}
             - secretRef:
-                name: {{ include "document-engine.storage.s3.secret.name" . }}
+                name: {{ .Values.assetStorage.s3.externalSecretName }}
           {{- end }}
           {{- with .Values.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}

--- a/charts/document-engine/values.yaml
+++ b/charts/document-engine/values.yaml
@@ -439,7 +439,7 @@ assetStorage:
     # -- `USE_REDIS_CACHE`
     # @section -- 07. Asset storage
     enabled: false
-    # -- `REDIS_TTL`
+    # -- `REDIS_TTL` (seconds)
     # @section -- 07. Asset storage
     ttlSeconds: 86400000
     # -- `USE_REDIS_TTL_FOR_PRERENDERING`


### PR DESCRIPTION
Hi PSPDFKit team — thanks for maintaining these charts!

This PR makes three small, backwards‑compatible improvements to the document-engine chart:

1) Migration Job secretRefs: inline credentials
   - Problem: When S3/Redis credentials are provided inline (no externalSecretName), the Deployment reads them from the main Secret, but the migration Job still envFroms separate "-s3" / "-redis" Secrets which are not created.
   - Change: The Job now includes those extra secretRefs only when an externalSecretName is set. Otherwise it relies on the main Secret (already included via envFrom), matching the Deployment behavior.
   - Effect: Users with inline creds no longer hit CreateContainerConfigError for missing "<fullname>-s3" / "<fullname>-redis" Secrets, while users with external secrets continue to work unchanged.

2) Azure helper secret name
   - Fixes a small typo in the helper that generated an "-s3" suffix for Azure’s secret name. It now uses an "-azure" suffix.

3) Redis TTL units clarification
   - Clarifies in values.yaml that `assetStorage.redis.ttlSeconds` is expressed in seconds. The ConfigMap renders REDIS_TTL directly from this value (other timeouts are converted to ms), so this avoids confusion with ms‑style defaults.

Notes
- No templates were removed; behavior is conditional and backwards‑compatible.
- No sensitive values involved; this only affects naming and conditionals.

Happy to adjust naming/wording if you prefer a different approach. Thanks again!
