### PR TITLE
Migrate MinIO to Garage

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -66,30 +66,112 @@ jobs:
             --namespace cnpg-system --create-namespace \
             cnpg/cloudnative-pg
 
-      - name: Install MinIO
+      - name: Install Garage
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm repo add minio https://operator.min.io/
-          # Install operator with minimal resources
-          helm upgrade --install \
-            --namespace minio-operator --create-namespace \
-            minio-operator minio/operator
-          helm upgrade --install \
-            --namespace whatever --create-namespace \
-            --set tenant.name=s3thing \
-            --set tenant.pools[0].name=pool-0 \
-            --set tenant.pools[0].servers=1 \
-            --set tenant.pools[0].volumesPerServer=1 \
-            --set tenant.pools[0].size=256Mi \
-            --set tenant.pools[0].storageClassName=standard \
-            --set tenant.certificate.requestAutoCert=false \
-            --set tenant.configSecret.accessKey=nutrient \
-            --set tenant.configSecret.secretKey=despairIsUnbearable87 \
-            --set tenant.buckets[0].name=whatever \
-            --set tenant.buckets[0].region=us-east-1 \
-            tenant minio/tenant
-          sleep 30
-          kubectl wait --namespace whatever --for=condition=ready pod -l v1.min.io/tenant=s3thing --timeout=300s
+          kubectl create namespace whatever --dry-run=client -o yaml | kubectl apply -f -
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: garage-config
+            namespace: whatever
+          data:
+            garage.toml: |
+              metadata_dir = "/var/lib/garage/meta"
+              data_dir = "/var/lib/garage/data"
+              db_engine = "sqlite"
+
+              replication_factor = 1
+
+              rpc_bind_addr = "[::]:3901"
+              rpc_public_addr = "garage.whatever.svc.cluster.local:3901"
+              rpc_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+              [s3_api]
+              s3_region = "us-east-1"
+              api_bind_addr = "[::]:3900"
+
+              [admin]
+              api_bind_addr = "[::]:3903"
+              admin_token = "garage-admin-token-for-ci"
+              metrics_token = "garage-metrics-token-for-ci"
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: garage
+            namespace: whatever
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: garage
+            template:
+              metadata:
+                labels:
+                  app: garage
+              spec:
+                containers:
+                  - name: garage
+                    image: dxflrs/garage:v2.3.0
+                    imagePullPolicy: IfNotPresent
+                    args:
+                      - /garage
+                      - server
+                      - --single-node
+                      - --default-bucket
+                    env:
+                      - name: GARAGE_DEFAULT_ACCESS_KEY
+                        value: nutrient
+                      - name: GARAGE_DEFAULT_SECRET_KEY
+                        value: despairIsUnbearable87
+                      - name: GARAGE_DEFAULT_BUCKET
+                        value: whatever
+                    ports:
+                      - containerPort: 3900
+                        name: s3
+                      - containerPort: 3901
+                        name: rpc
+                      - containerPort: 3903
+                        name: admin
+                    volumeMounts:
+                      - name: config
+                        mountPath: /etc/garage.toml
+                        subPath: garage.toml
+                      - name: meta
+                        mountPath: /var/lib/garage/meta
+                      - name: data
+                        mountPath: /var/lib/garage/data
+                volumes:
+                  - name: config
+                    configMap:
+                      name: garage-config
+                  - name: meta
+                    emptyDir: {}
+                  - name: data
+                    emptyDir: {}
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: garage
+            namespace: whatever
+          spec:
+            selector:
+              app: garage
+            ports:
+              - name: s3
+                port: 80
+                targetPort: 3900
+              - name: rpc
+                port: 3901
+                targetPort: 3901
+              - name: admin
+                port: 3903
+                targetPort: 3903
+          EOF
+          kubectl rollout status deployment/garage --namespace whatever --timeout=300s
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -65,6 +65,23 @@ jobs:
           helm upgrade --install cnpg \
             --namespace cnpg-system --create-namespace \
             cnpg/cloudnative-pg
+          kubectl wait \
+            --namespace cnpg-system \
+            --for=condition=Available=true \
+            deployment \
+            -l app.kubernetes.io/name=cloudnative-pg \
+            --timeout=300s
+          kubectl wait \
+            --namespace cnpg-system \
+            --for=condition=Ready=true \
+            pod \
+            -l app.kubernetes.io/name=cloudnative-pg \
+            --timeout=300s
+          kubectl wait \
+            --namespace cnpg-system \
+            --for=jsonpath='{.subsets[0].addresses[0].ip}' \
+            endpoints/cnpg-webhook-service \
+            --timeout=300s
 
       - name: Install Garage
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -189,6 +189,42 @@ jobs:
                 targetPort: 3903
           EOF
           kubectl rollout status deployment/garage --namespace whatever --timeout=300s
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: garage-create-buckets
+            namespace: whatever
+          spec:
+            backoffLimit: 6
+            template:
+              spec:
+                restartPolicy: OnFailure
+                containers:
+                  - name: aws-cli
+                    image: amazon/aws-cli:2.17.40
+                    imagePullPolicy: IfNotPresent
+                    command:
+                      - /bin/sh
+                      - -ec
+                      - |
+                        until aws --endpoint-url http://garage.whatever.svc.cluster.local s3 ls >/dev/null 2>&1; do
+                          sleep 1
+                        done
+                        aws --endpoint-url http://garage.whatever.svc.cluster.local s3api create-bucket \
+                          --bucket whatever \
+                          --region us-east-1 || true
+                    env:
+                      - name: AWS_ACCESS_KEY_ID
+                        value: nutrient
+                      - name: AWS_SECRET_ACCESS_KEY
+                        value: despairIsUnbearable87
+                      - name: AWS_DEFAULT_REGION
+                        value: us-east-1
+                      - name: AWS_EC2_METADATA_DISABLED
+                        value: "true"
+          EOF
+          kubectl wait --namespace whatever --for=condition=complete job/garage-create-buckets --timeout=300s
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Chart.lock
 #*.tgz
 #index.yaml
 charts/*/charts
+
+# Codex
+.codex

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ These annotations drive README and schema generation:
 Three GitHub Actions workflows run on this repository:
 
 1. **Documentation** (`helm-docs.yaml`) — PR trigger. Validates README.md is in sync with values.yaml. Fails on diff.
-2. **Lint and Test** (`lint-test.yaml`) — PR trigger. Runs `ct lint` and `ct install` against a Kind cluster with CloudNativePG and MinIO pre-installed.
+2. **Lint and Test** (`lint-test.yaml`) — PR trigger. Runs `ct lint` and `ct install` against a Kind cluster with CloudNativePG and Garage pre-installed.
 3. **Release** (`release.yml`) — Push to `master`. Publishes chart releases via chart-releaser and updates GitHub release notes from CHANGELOG.md.
 
 ## CI Test Values
@@ -81,7 +81,7 @@ Each chart has a `ci/` directory with test value files used by `ct install`:
 ci/00-simple-values.yaml          # Symlink to values.simple.yaml
 ci/01-no-storage-values.yaml      # No database
 ci/02-cnpg-clustering-values.yaml # CloudNativePG clustering + StatefulSet
-ci/03-cnpg-s3-redis-values.yaml   # MinIO S3 + Redis
+ci/03-cnpg-s3-redis-values.yaml   # Garage S3 + Redis
 ci/04-cnpg-azure-values.yaml      # Azure Blob storage
 ci/05-envoy-sidecar-values.yaml   # Envoy sidecar + StatefulSet
 ci/10-env-variables-values.yaml   # Raw environment variables

--- a/charts/document-engine/CHANGELOG.md
+++ b/charts/document-engine/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [8.2.2 (2026-04-20)](#822-2026-04-20)
+    - [Changed](#changed)
   - [8.2.1 (2026-04-09)](#821-2026-04-09)
     - [Changed](#changed)
   - [8.2.0 (2026-03-26)](#820-2026-03-26)
@@ -224,6 +226,12 @@
     - [Changed](#changed-61)
   - [2.0.0](#200)
     - [Changed](#changed-62)
+
+## 8.2.2 (2026-04-20)
+
+### Changed
+
+* MinIO references replaced with Garage
 
 ## 8.2.1 (2026-04-09)
 

--- a/charts/document-engine/Chart.yaml
+++ b/charts/document-engine/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: Document Engine is a backend software for processing documents and powering automation workflows.
 home: https://www.nutrient.io/sdk/document-engine
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 8.2.1
+version: 8.2.2
 appVersion: "1.15.1"
 
 keywords:

--- a/charts/document-engine/README.md
+++ b/charts/document-engine/README.md
@@ -97,10 +97,10 @@ CloudNativePG is not the only possible solution, and we recommend to also consid
 To offload the bulk of binary storage from the database,
 Document Engine can [utilise](https://www.nutrient.io/guides/document-engine/configuration/asset-storage/) S3-compatible object storage or Azure Blob Storage.
 
-In addition to the managed services (Amazon S3, Google Cloud Storage, many others), there are also options for self-hosting, including, but not limited to [Ceph](https://ceph.io/en/), [MinIO](https://www.min.io/).
+In addition to the managed services (Amazon S3, Google Cloud Storage, many others), there are also options for self-hosting, including, but not limited to [Ceph](https://ceph.io/en/), [Garage](https://garagehq.deuxfleurs.fr/).
 
-The latter is a popular way to implement S3-compatible buckets in a vendor-agnostic way.
-However, due to very limited Custom Resource Definitions ecosystem in MinIO, this chart is not attempting to provide a plug-in support for it.
+The latter is a lightweight way to implement S3-compatible buckets in a vendor-agnostic way.
+However, this chart does not attempt to manage Garage resources directly.
 
 ## Rendering cache
 

--- a/charts/document-engine/README.md
+++ b/charts/document-engine/README.md
@@ -1,6 +1,6 @@
 # Document Engine Helm chart
 
-![Version: 8.2.1](https://img.shields.io/badge/Version-8.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
+![Version: 8.2.2](https://img.shields.io/badge/Version-8.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
 
 Document Engine is a backend software for processing documents and powering automation workflows.
 

--- a/charts/document-engine/README.md.gotmpl
+++ b/charts/document-engine/README.md.gotmpl
@@ -192,10 +192,10 @@ CloudNativePG is not the only possible solution, and we recommend to also consid
 To offload the bulk of binary storage from the database, 
 Document Engine can [utilise](https://www.nutrient.io/guides/document-engine/configuration/asset-storage/) S3-compatible object storage or Azure Blob Storage.
 
-In addition to the managed services (Amazon S3, Google Cloud Storage, many others), there are also options for self-hosting, including, but not limited to [Ceph](https://ceph.io/en/), [MinIO](https://www.min.io/).
+In addition to the managed services (Amazon S3, Google Cloud Storage, many others), there are also options for self-hosting, including, but not limited to [Ceph](https://ceph.io/en/), [Garage](https://garagehq.deuxfleurs.fr/).
 
-The latter is a popular way to implement S3-compatible buckets in a vendor-agnostic way. 
-However, due to very limited Custom Resource Definitions ecosystem in MinIO, this chart is not attempting to provide a plug-in support for it.
+The latter is a lightweight way to implement S3-compatible buckets in a vendor-agnostic way.
+However, this chart does not attempt to manage Garage resources directly.
 
 ## Rendering cache
 

--- a/charts/document-engine/ci/03-cnpg-s3-redis-values.yaml
+++ b/charts/document-engine/ci/03-cnpg-s3-redis-values.yaml
@@ -20,7 +20,7 @@ assetStorage:
     secretAccessKey: despairIsUnbearable87
     bucket: whatever
     region: us-east-1
-    host: minio.whatever.svc.cluster.local
+    host: garage.whatever.svc.cluster.local
     port: 80
     scheme: "http://"
   redis:

--- a/charts/document-engine/ci/README.md
+++ b/charts/document-engine/ci/README.md
@@ -13,7 +13,7 @@
   * Gateway API HTTPRoute with custom rules
 * `03-cnpg-s3-redis-values.yaml`
   * PostgreSQL
-  * MinIO as S3 asset storage backend through MinIO operator
+  * Garage as S3 asset storage backend
   * Redis for rendering cache as a sidecar container
   * `gateway.extraHTTPRoutes` for dashboard
 * `04-cnpg-azure-values.yaml`

--- a/charts/document-engine/values.yaml
+++ b/charts/document-engine/values.yaml
@@ -396,7 +396,7 @@ assetStorage:
     # -- (tpl/string) `ASSET_STORAGE_S3_HOST`
     # @section -- 07. Asset storage
     # @ignored
-    # host: "{{ .Release.Name }}-minio"
+    # host: "{{ .Release.Name }}-garage"
     host: ""
     # -- `ASSET_STORAGE_S3_PORT`
     # @section -- 07. Asset storage


### PR DESCRIPTION
MinIO was in "maintenance mode" [1] for some time. However, the MinIO
repository is archived now [2] and is no longer accepting any changes.
Docker images were updated 7 months ago as well. [3]

There are many alternatives, be it:

- Garage [4]
- SeaweedFS [5]
- Ceph w/ RadosGW [6]

Picked Garage for its simplicity.

[1] https://www.reddit.com/r/selfhosted/comments/1pd97nq/minio_is_in_maintenance_mode_and_is_no_longer/

[2] https://github.com/minio/minio

[3] https://hub.docker.com/r/minio/minio/tags

[4] https://garagehq.deuxfleurs.fr

[5] https://github.com/seaweedfs/seaweedfs

[6] https://docs.ceph.com/en/latest/radosgw/s3/