### PR TITLE
[AIA] set spec.owner on CNPG Database resources

### DIFF
--- a/charts/ai-assistant/CHANGELOG.md
+++ b/charts/ai-assistant/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [1.2.1 (2026-05-20)](#121-2026-05-20)
+    - [Fixed](#fixed)
   - [1.2.0 (2026-03-05)](#120-2026-03-05)
     - [Changed](#changed-9)
   - [1.1.0 (2026-02-28)](#110-2026-02-28)
@@ -26,6 +28,12 @@
     - [Changed](#changed-8)
   - [0.0.1 (2025-05-28)](#001-2025-05-28)
     - [Added](#added-3)
+
+## 1.2.1 (2026-05-20)
+
+### Fixed
+
+* `cloudNativePG.Database` and `cloudNativePG.document-engine.Database` resources now set the required `spec.owner` field. Without it the CloudNativePG admission webhook rejects the resources with `Database.postgresql.cnpg.io ... is invalid: [spec.owner: Required value, ...]`, breaking install of the chart when `cloudNativePG.enabled` is `true`. `owner` is sourced from `database.postgres.username` (defaults to `postgres`, which exists in the cluster via `clusterSpec.enableSuperuserAccess: true`).
 
 ## 1.2.0 (2026-03-05)
 

--- a/charts/ai-assistant/Chart.yaml
+++ b/charts/ai-assistant/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 description: AI Assistant is a thing that assists an AI
 home: https://www.nutrient.io/guides/ai-assistant/
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 1.2.0
+version: 1.2.1
 appVersion: "2.1.0"
 
 keywords:

--- a/charts/ai-assistant/README.md
+++ b/charts/ai-assistant/README.md
@@ -1,6 +1,6 @@
 # AI Assistant Helm chart
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 AI Assistant is a thing that assists an AI
 

--- a/charts/ai-assistant/templates/storage/cloudNativePG.Database.yaml
+++ b/charts/ai-assistant/templates/storage/cloudNativePG.Database.yaml
@@ -11,6 +11,7 @@ spec:
     name: {{ include "ai-assistant.storage.cloudNativePG.cluster.name" . }}
 {{- with .Values.database.postgres }}
   name: {{ .database }}
+  owner: {{ .username }}
 {{- end }}
   extensions:
     - name: vector

--- a/charts/ai-assistant/templates/storage/cloudNativePG.document-engine.Database.yaml
+++ b/charts/ai-assistant/templates/storage/cloudNativePG.document-engine.Database.yaml
@@ -13,4 +13,5 @@ spec:
 {{- with .Values.cloudNativePG.documentEngineDatabase }}
   name: {{ .name }}
 {{- end }}
+  owner: {{ .Values.database.postgres.username }}
 {{- end }}


### PR DESCRIPTION
## Why

The CloudNativePG `Database` CRD requires `spec.owner`. The `ai-assistant` chart's two `Database` resources don't set it, so the admission webhook rejects them at install time:

```
Error: INSTALLATION FAILED: 2 errors occurred:
  * Database.postgresql.cnpg.io "<release>-postgres-de" is invalid: [spec.owner: Required value, ...]
  * Database.postgresql.cnpg.io "<release>-postgres"    is invalid: [spec.owner: Required value, ...]
```

This breaks `ct install` for the `ai-assistant` chart and any real install against any current CNPG. The failure wasn't caught earlier because every recent CI run on `master` happened to change only `document-engine`, so `ct install` for `ai-assistant` hadn't been exercised in a while.

`spec.owner` has been in the `Database` CRD's `required` list since [CNPG v1.25.0 (2024‑12‑23)](https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.25.0) — the very first release that introduced the `Database` CRD ([see `required: [cluster, name, owner]` in the v1.25.0 CRD source](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.25.0/config/crd/bases/postgresql.cnpg.io_databases.yaml)). So this hasn't been broken by a recent upstream change — the chart simply needed `owner` from the moment the `Database` CRs were introduced.

## Summary

- Add `owner` to both `Database` templates (`cloudNativePG.Database.yaml` and `cloudNativePG.document-engine.Database.yaml`).
- Source it from the existing `database.postgres.username` value — that's the superuser that already exists in the cluster (`clusterSpec.enableSuperuserAccess: true`, `superuserSecret.username: postgres` by default), so no new values are introduced.
- No other chart changes.

## Note on `cloudNativePG.document-engine.Database.yaml`

Worth being explicit about this one, since the file name is slightly misleading: it doesn't actually belong to document-engine — it provisions a `document_engine` database **inside AIA's own CNPG cluster**, owned by AIA's connection user. It's gated `enabled: false` by default and only fires in a "shared cluster" deployment where someone explicitly wants one Postgres cluster behind both apps. In the default config it doesn't render. The fix sets `owner` to AIA's `database.postgres.username` for the same reason the AIA Database template does — that's the role we know exists in AIA's cluster. If the shared-cluster mode needs a different owner long-term, that's a chart-design conversation, separate from fixing the immediate CRD validation failure.