### PR TITLE
[maestrod] Update to 1.1.2

### DIFF
--- a/charts/maestrod/CHANGELOG.md
+++ b/charts/maestrod/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.6.1 (2026-05-30)](#061-2026-05-30)
+    - [Changed](#changed)
   - [0.6.0 (2026-05-29)](#060-2026-05-29)
     - [Added](#added)
   - [0.5.0 (2026-05-27)](#050-2026-05-27)
     - [Added](#added-1)
+
+## 0.6.1 (2026-05-30)
+
+### Changed
+
+- Updated maestrod appVersion to `1.1.2`.
 
 ## 0.6.0 (2026-05-29)
 

--- a/charts/maestrod/Chart.yaml
+++ b/charts/maestrod/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 description: Maestrod, the orchestration backend for Nutrient managed cloud workloads.
 home: https://www.nutrient.io
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 0.6.0
-appVersion: "v1.1.1"
+version: 0.6.1
+appVersion: "1.1.2"
 
 keywords:
   - nutrient

--- a/charts/maestrod/README.md
+++ b/charts/maestrod/README.md
@@ -2,7 +2,7 @@
 
 > [!WARNING] This chart is made for internal use by Nutrient.
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.1](https://img.shields.io/badge/AppVersion-v1.1.1-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 Maestrod, the orchestration backend for Nutrient managed cloud workloads.
 


### PR DESCRIPTION
Updates maestrod helm chart to version 1.1.2

- Chart version: 0.6.0 → 0.6.1
- AppVersion: v1.1.1 → 1.1.2
- Updated CHANGELOG.md
- Regenerated README.md and values.schema.json