### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -10,26 +10,26 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Run helm-docs for Document Engine
-        uses: losisin/helm-docs-github-action@v1
+        uses: losisin/helm-docs-github-action@2ccf3e77eb70dc80d62f8cc26f15d0a96b75fef4 # v1
         with:
           chart-search-root: charts/document-engine
           # git-push: true
           fail-on-diff: true
 
       - name: Run helm-docs for AI Assistant
-        uses: losisin/helm-docs-github-action@v1
+        uses: losisin/helm-docs-github-action@2ccf3e77eb70dc80d62f8cc26f15d0a96b75fef4 # v1
         with:
           chart-search-root: charts/ai-assistant
           # git-push: true
           fail-on-diff: true
 
       - name: Run helm-docs for Maestrod
-        uses: losisin/helm-docs-github-action@v1
+        uses: losisin/helm-docs-github-action@2ccf3e77eb70dc80d62f8cc26f15d0a96b75fef4 # v1
         with:
           chart-search-root: charts/maestrod
           # git-push: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,22 +23,22 @@ jobs:
       AWS_REGION: eu-west-1
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: latest
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -60,18 +60,18 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
       - name: Configure AWS credentials (for ECR pull)
         if: steps.list-changed.outputs.maestrod-changed == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
         with:
           role-to-assume: ${{ secrets.AWS_CI_ECR_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         if: steps.list-changed.outputs.maestrod-changed == 'true'
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Side-load maestrod image into kind
         if: steps.list-changed.outputs.maestrod-changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           skip_existing: true
           mark_as_latest: true


### PR DESCRIPTION
## Summary

Pins GitHub Actions `uses:` references to verified full-length commit SHAs.

This prepares the repository for orgwide enforcement that blocks unpinned GitHub Actions and reduces supply-chain risk from mutable tags or branches.

## Details

- Replaced mutable external action refs such as `owner/action@vN` with full 40-character commit SHAs.
- Preserved the originally intended tag/version as an inline comment next to each pin.
- Resolved SHAs from the official upstream action repositories using `git ls-remote`.
- For annotated tags, pinned the peeled commit SHA (`refs/tags/<tag>^{}`), not the tag object SHA.
- No workflow behavior, inputs, permissions, or triggers were intentionally changed.