### PR TITLE
Document Engine 1.17.0

### DIFF
--- a/charts/document-engine/CHANGELOG.md
+++ b/charts/document-engine/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [8.5.0 (2026-06-29)](#850-2026-06-29)
   - [8.4.0 (2026-05-28)](#840-2026-05-28)
     - [Added](#added)
     - [Changed](#changed)
@@ -235,6 +236,13 @@
     - [Changed](#changed-67)
   - [2.0.0](#200)
     - [Changed](#changed-68)
+
+## 8.5.0 (2026-06-29)
+
+* Updated Document Engine to 1.17.0.
+* Added Helm values for async job admission, worker queues, retry, retention, and encryption settings.
+* Added external Secret support for `ASYNC_JOB_ENCRYPTION_KEYS`.
+* Added Helm values for batch render, remote URL fetch policy, and full-text search settings.
 
 ## 8.4.0 (2026-05-28)
 

--- a/charts/document-engine/Chart.yaml
+++ b/charts/document-engine/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 description: Document Engine is a backend software for processing documents and powering automation workflows.
 home: https://www.nutrient.io/sdk/document-engine
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 8.4.0
-appVersion: "1.16.0"
+version: 8.5.0
+appVersion: "1.17.0"
 
 keywords:
   - nutrient

--- a/charts/document-engine/README.md
+++ b/charts/document-engine/README.md
@@ -1,6 +1,6 @@
 # Document Engine Helm chart
 
-![Version: 8.4.0](https://img.shields.io/badge/Version-8.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 8.5.0](https://img.shields.io/badge/Version-8.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 Document Engine is a backend software for processing documents and powering automation workflows.
 
@@ -404,29 +404,55 @@ Note:
 | Key | Description | Default |
 |-----|-------------|---------|
 | [`config`](./values.yaml#L82) | General configuration, see more in [our guide](https://www.nutrient.io/guides/document-engine/configuration/options/) |  |
-| [`config.allowDocumentGeneration`](./values.yaml#L127) | `ALLOW_DOCUMENT_GENERATION` | `true` |
-| [`config.allowDocumentUploads`](./values.yaml#L121) | `ALLOW_DOCUMENT_UPLOADS` | `true` |
-| [`config.allowRemoteAssetsInGeneration`](./values.yaml#L130) | `ALLOW_REMOTE_ASSETS_IN_GENERATION` | `true` |
-| [`config.allowRemoteDocuments`](./values.yaml#L124) | `ALLOW_REMOTE_DOCUMENTS` | `true` |
-| [`config.asyncJobsTtlSeconds`](./values.yaml#L118) | `ASYNC_JOBS_TTL` | `172800` |
-| [`config.automaticLinkExtraction`](./values.yaml#L136) | `AUTOMATIC_LINK_EXTRACTION` | `false` |
+| [`config.allowDocumentGeneration`](./values.yaml#L187) | `ALLOW_DOCUMENT_GENERATION` | `true` |
+| [`config.allowDocumentUploads`](./values.yaml#L181) | `ALLOW_DOCUMENT_UPLOADS` | `true` |
+| [`config.allowRemoteAssetsInGeneration`](./values.yaml#L190) | `ALLOW_REMOTE_ASSETS_IN_GENERATION` | `true` |
+| [`config.allowRemoteDocuments`](./values.yaml#L184) | `ALLOW_REMOTE_DOCUMENTS` | `true` |
+| [`config.asyncAdmissionQueueLimits`](./values.yaml#L153) | `ASYNC_ADMISSION_QUEUE_LIMITS` — optional comma-separated queue limits, for example `default=100`. Missing queues are unlimited. | `none` |
+| [`config.asyncAdmissionQueues`](./values.yaml#L148) | `ASYNC_ADMISSION_QUEUES` — comma-separated async queues accepted by this node. Set to an empty string to reject async operation admission. | `"default"` |
+| [`config.asyncJobEncryption`](./values.yaml#L162) | Async job metadata encryption settings. | [...](./values.yaml#L162) |
+| [`config.asyncJobEncryption.externalSecret`](./values.yaml#L172) | Use an external secret for `ASYNC_JOB_ENCRYPTION_KEYS` | [...](./values.yaml#L172) |
+| [`config.asyncJobEncryption.externalSecret.key`](./values.yaml#L178) | Secret key name for the async job encryption keyring | `"ASYNC_JOB_ENCRYPTION_KEYS"` |
+| [`config.asyncJobEncryption.externalSecret.name`](./values.yaml#L175) | External secret name | `""` |
+| [`config.asyncJobEncryption.keys`](./values.yaml#L167) | `ASYNC_JOB_ENCRYPTION_KEYS` — comma-separated `key_id:base64_key[:current]` entries for encrypting async job metadata. Required for async Build API requests with remote URLs or PDF passwords. | `none` |
+| [`config.asyncJobMaxRetries`](./values.yaml#L141) | `ASYNC_JOB_MAX_RETRIES` | `2` |
+| [`config.asyncJobRetryBackoffSeconds`](./values.yaml#L144) | `ASYNC_JOB_RETRY_BACKOFF_SECONDS` | `15` |
+| [`config.asyncJobTimeoutSeconds`](./values.yaml#L138) | `ASYNC_JOB_TIMEOUT` in seconds | `600` |
+| [`config.asyncJobsMetadataTtlSeconds`](./values.yaml#L135) | `ASYNC_JOBS_METADATA_TTL` in seconds. Must be greater than or equal to `config.asyncJobsTtlSeconds`. | `604800` |
+| [`config.asyncJobsTtlSeconds`](./values.yaml#L132) | `ASYNC_JOBS_TTL` | `172800` |
+| [`config.asyncWorkerQueues`](./values.yaml#L157) | `ASYNC_WORKER_QUEUES` — comma-separated async worker queues with concurrency, for example `default=5`. Set to an empty string to make this node skip async background work. | `"default=5"` |
+| [`config.automaticLinkExtraction`](./values.yaml#L196) | `AUTOMATIC_LINK_EXTRACTION` | `false` |
+| [`config.batchRender`](./values.yaml#L117) | Batch render request settings. | [...](./values.yaml#L117) |
+| [`config.batchRender.maxConcurrency`](./values.yaml#L120) | `BATCH_RENDER_MAX_CONCURRENCY` | `4` |
+| [`config.batchRender.maxPages`](./values.yaml#L123) | `BATCH_RENDER_MAX_PAGES` | `500` |
+| [`config.batchRender.pageTimeoutSeconds`](./values.yaml#L126) | `BATCH_RENDER_PAGE_TIMEOUT_MS` in seconds | `120` |
 | [`config.daemonReadTimeoutSeconds`](./values.yaml#L100) | `PSPDFKITD_READ_TIMEOUT` in seconds | `120` |
 | [`config.daemonWriteTimeoutSeconds`](./values.yaml#L103) | `PSPDFKITD_WRITE_TIMEOUT` in seconds | `10` |
 | [`config.generationTimeoutSeconds`](./values.yaml#L106) | `PDF_GENERATION_TIMEOUT` in seconds | `20` |
-| [`config.hoard`](./values.yaml#L149) | Hoard — internal caching service parameters | [...](./values.yaml#L149) |
-| [`config.hoard.maxSizeMegaBytes`](./values.yaml#L152) | `HOARD_MAX_SIZE` — maximum size in millions of bytes | `100` |
-| [`config.http2SharedRendering`](./values.yaml#L161) | Optimised rendering relying on HTTP/2 | [...](./values.yaml#L161) |
-| [`config.http2SharedRendering.enabled`](./values.yaml#L164) | `HTTP2_SHARED_RENDERING_PROCESS_ENABLE` — enable shared rendering processes | `false` |
-| [`config.ignoreInvalidAnnotations`](./values.yaml#L133) | `IGNORE_INVALID_ANNOTATIONS` | `true` |
-| [`config.maxUploadSizeMegaBytes`](./values.yaml#L115) | `MAX_UPLOAD_SIZE_BYTES` in megabytes | `950` |
-| [`config.minSearchQueryLength`](./values.yaml#L139) | `MIN_SEARCH_QUERY_LENGTH` | `3` |
-| [`config.port`](./values.yaml#L182) | `PORT` for the Document Engine API | `5000` |
-| [`config.proxy`](./values.yaml#L177) | Proxy settings, `HTTP_PROXY` and `HTTPS_PROXY` | `{"http":"","https":""}` |
+| [`config.hoard`](./values.yaml#L245) | Hoard — internal caching service parameters | [...](./values.yaml#L245) |
+| [`config.hoard.maxSizeMegaBytes`](./values.yaml#L248) | `HOARD_MAX_SIZE` — maximum size in millions of bytes | `100` |
+| [`config.http2SharedRendering`](./values.yaml#L257) | Optimised rendering relying on HTTP/2 | [...](./values.yaml#L257) |
+| [`config.http2SharedRendering.enabled`](./values.yaml#L260) | `HTTP2_SHARED_RENDERING_PROCESS_ENABLE` — enable shared rendering processes | `false` |
+| [`config.ignoreInvalidAnnotations`](./values.yaml#L193) | `IGNORE_INVALID_ANNOTATIONS` | `true` |
+| [`config.maxUploadSizeMegaBytes`](./values.yaml#L129) | `MAX_UPLOAD_SIZE_BYTES` in megabytes | `950` |
+| [`config.minSearchQueryLength`](./values.yaml#L199) | `MIN_SEARCH_QUERY_LENGTH` | `3` |
+| [`config.port`](./values.yaml#L278) | `PORT` for the Document Engine API | `5000` |
+| [`config.proxy`](./values.yaml#L273) | Proxy settings, `HTTP_PROXY` and `HTTPS_PROXY` | `{"http":"","https":""}` |
 | [`config.readAnnotationBatchTimeoutSeconds`](./values.yaml#L112) | `READ_ANNOTATION_BATCH_TIMEOUT` in seconds | `20` |
-| [`config.replaceSecretsFromEnv`](./values.yaml#L187) | `REPLACE_SECRETS_FROM_ENV` — whether to consider environment variables, values and secrets for `JWT_PUBLIC_KEY`, `SECRET_KEY_BASE` and `DASHBOARD_PASSWORD` | `true` |
+| [`config.remoteUrlFetch`](./values.yaml#L204) | Customer-controlled remote URL fetch policy. | [...](./values.yaml#L204) |
+| [`config.remoteUrlFetch.allowEmbeddedCredentials`](./values.yaml#L218) | `REMOTE_URL_FETCH_ALLOW_EMBEDDED_CREDENTIALS` | `false` |
+| [`config.remoteUrlFetch.allowedCidrs`](./values.yaml#L215) | `REMOTE_URL_FETCH_ALLOWED_CIDRS` — comma-separated CIDR ranges. | `none` |
+| [`config.remoteUrlFetch.allowedHosts`](./values.yaml#L211) | `REMOTE_URL_FETCH_ALLOWED_HOSTS` — comma-separated DNS hostnames or wildcard DNS patterns. | `none` |
+| [`config.remoteUrlFetch.policy`](./values.yaml#L207) | `REMOTE_URL_FETCH_POLICY` | `"public_only"` |
+| [`config.replaceSecretsFromEnv`](./values.yaml#L283) | `REPLACE_SECRETS_FROM_ENV` — whether to consider environment variables, values and secrets for `JWT_PUBLIC_KEY`, `SECRET_KEY_BASE` and `DASHBOARD_PASSWORD` | `true` |
 | [`config.requestTimeoutSeconds`](./values.yaml#L88) | Full request timeout in seconds (`SERVER_REQUEST_TIMEOUT`). Should be lesser than `terminationGracePeriodSeconds`. | `60` |
-| [`config.tileMaxScale`](./values.yaml#L144) | `TILE_MAX_SCALE` — maximum allowed tile scale, calculated as requested tile size divided by actual page size. Must be greater than 1. When unset, no limit is enforced. | `unlimited` |
-| [`config.trustedProxies`](./values.yaml#L174) | `TRUSTED_PROXIES` — comma-separated list of IP addresses or IP address ranges of trusted proxies. Setting to `default` will use private IP ranges. | `"default"` |
+| [`config.search`](./values.yaml#L223) | Full-text search settings. | [...](./values.yaml#L223) |
+| [`config.search.ftsBuildOnWrite`](./values.yaml#L235) | `SEARCH_FTS_BUILD_ON_WRITE` | `false` |
+| [`config.search.ftsEnabled`](./values.yaml#L226) | `SEARCH_FTS_ENABLED` | `false` |
+| [`config.search.ftsEnrichment`](./values.yaml#L229) | `SEARCH_FTS_ENRICHMENT` | `"daemon"` |
+| [`config.search.maxGlyphSidecarPageBytes`](./values.yaml#L232) | `SEARCH_MAX_GLYPH_SIDECAR_PAGE_BYTES` | `2000000` |
+| [`config.tileMaxScale`](./values.yaml#L240) | `TILE_MAX_SCALE` — maximum allowed tile scale, calculated as requested tile size divided by actual page size. Must be greater than 1. When unset, no limit is enforced. | `unlimited` |
+| [`config.trustedProxies`](./values.yaml#L270) | `TRUSTED_PROXIES` — comma-separated list of IP addresses or IP address ranges of trusted proxies. Setting to `default` will use private IP ranges. | `"default"` |
 | [`config.urlFetchTimeoutSeconds`](./values.yaml#L109) | `REMOTE_URL_FETCH_TIMEOUT` in seconds | `5` |
 | [`config.workerPoolMaxRestarts`](./values.yaml#L94) | Maximum number of restarts (`PSPDFKIT_WORKER_POOL_MAX_RESTARTS`) before supervisor starts throttling them. | `20` |
 | [`config.workerPoolMaxSeconds`](./values.yaml#L97) | Time window in which the supervisor monitors the number of restarts (`PSPDFKIT_WORKER_POOL_MAX_SECONDS`). | `60` |
@@ -437,123 +463,123 @@ Note:
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`certificateTrust`](./values.yaml#L192) | [Certificate trust](https://www.nutrient.io/guides/document-engine/configuration/certificate-trust/) |  |
-| [`certificateTrust.customCertificates`](./values.yaml#L205) | ConfigMap and Secret references for trust configuration, stored in `/certificate-stores-custom` | `[]` |
-| [`certificateTrust.digitalSignatures`](./values.yaml#L196) | CAs for digital signatures (`/certificate-stores/`) from ConfigMap and Secret resources. | `[]` |
-| [`certificateTrust.downloaderTrustFileName`](./values.yaml#L215) | Override `DOWNLOADER_CERT_FILE_PATH` to set HTTP client trust. If empty, defaults to  Mozilla's CA bundle. | `""` |
+| [`certificateTrust`](./values.yaml#L288) | [Certificate trust](https://www.nutrient.io/guides/document-engine/configuration/certificate-trust/) |  |
+| [`certificateTrust.customCertificates`](./values.yaml#L301) | ConfigMap and Secret references for trust configuration, stored in `/certificate-stores-custom` | `[]` |
+| [`certificateTrust.digitalSignatures`](./values.yaml#L292) | CAs for digital signatures (`/certificate-stores/`) from ConfigMap and Secret resources. | `[]` |
+| [`certificateTrust.downloaderTrustFileName`](./values.yaml#L311) | Override `DOWNLOADER_CERT_FILE_PATH` to set HTTP client trust. If empty, defaults to  Mozilla's CA bundle. | `""` |
 
 ### Database
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`database`](./values.yaml#L220) | Database |  |
-| [`database.connections`](./values.yaml#L229) | `DATABASE_CONNECTIONS` | `20` |
-| [`database.enabled`](./values.yaml#L223) | Persistent storage enabled | `true` |
-| [`database.engine`](./values.yaml#L226) | Database engine: only `postgres` is currently supported | `"postgres"` |
-| [`database.migrationJob`](./values.yaml#L293) | Database migration jobs. | [...](./values.yaml#L293) |
-| [`database.migrationJob.enabled`](./values.yaml#L296) | It `true`, results in `ENABLE_DATABASE_MIGRATIONS=false` in the main Document Engine container | `false` |
-| [`database.postgres`](./values.yaml#L234) | PostgreSQL database settings | [...](./values.yaml#L234) |
-| [`database.postgres.adminPassword`](./values.yaml#L255) | `PG_ADMIN_PASSWORD` | `"despair"` |
-| [`database.postgres.adminUsername`](./values.yaml#L252) | `PG_ADMIN_USER` | `"postgres"` |
-| [`database.postgres.database`](./values.yaml#L243) | `PGDATABASE` | `"document-engine"` |
-| [`database.postgres.externalAdminSecretName`](./values.yaml#L264) | External secret for administrative database credentials, used for migrations: `PG_ADMIN_USER` and `PG_ADMIN_PASSWORD` | `""` |
-| [`database.postgres.externalSecretName`](./values.yaml#L260) | Use external secret for database credentials. `PGUSER` and `PGPASSWORD` must be provided and, if not defined: `PGDATABASE`, `PGHOST`, `PGPORT`, `PGSSL` | `""` |
-| [`database.postgres.host`](./values.yaml#L237) | `PGHOST`, if not set, and `cloudNativePG.enabled`, will rely on the Cluster | `""` |
-| [`database.postgres.password`](./values.yaml#L249) | `PGPASSWORD` | `"despair"` |
-| [`database.postgres.port`](./values.yaml#L240) | `PGPORT` | `5432` |
-| [`database.postgres.tls`](./values.yaml#L269) | TLS settings | [...](./values.yaml#L269) |
-| [`database.postgres.tls.commonName`](./values.yaml#L282) | Common name for the certificate (`PGSSL_CERT_COMMON_NAME`), defaults to `PGHOST` value | `""` |
-| [`database.postgres.tls.enabled`](./values.yaml#L272) | Enable TLS (`PGSSL`) | `false` |
-| [`database.postgres.tls.hostVerify`](./values.yaml#L278) | Negated `PGSSL_DISABLE_HOSTNAME_VERIFY` | `true` |
-| [`database.postgres.tls.trustBundle`](./values.yaml#L286) | Trust bundle for PostgreSQL, sets `PGSSL_CA_CERTS`, mutually exclusive with `trustFileName` and takes precedence | `""` |
-| [`database.postgres.tls.trustFileName`](./values.yaml#L289) | Path from `certificateTrust.customCertificates`, wraps around `PGSSL_CA_CERT_PATH` | `""` |
-| [`database.postgres.tls.verify`](./values.yaml#L275) | Negated `PGSSL_DISABLE_VERIFY` | `true` |
-| [`database.postgres.username`](./values.yaml#L246) | `PGUSER` | `"postgres"` |
+| [`database`](./values.yaml#L316) | Database |  |
+| [`database.connections`](./values.yaml#L325) | `DATABASE_CONNECTIONS` | `20` |
+| [`database.enabled`](./values.yaml#L319) | Persistent storage enabled | `true` |
+| [`database.engine`](./values.yaml#L322) | Database engine: only `postgres` is currently supported | `"postgres"` |
+| [`database.migrationJob`](./values.yaml#L389) | Database migration jobs. | [...](./values.yaml#L389) |
+| [`database.migrationJob.enabled`](./values.yaml#L392) | It `true`, results in `ENABLE_DATABASE_MIGRATIONS=false` in the main Document Engine container | `false` |
+| [`database.postgres`](./values.yaml#L330) | PostgreSQL database settings | [...](./values.yaml#L330) |
+| [`database.postgres.adminPassword`](./values.yaml#L351) | `PG_ADMIN_PASSWORD` | `"despair"` |
+| [`database.postgres.adminUsername`](./values.yaml#L348) | `PG_ADMIN_USER` | `"postgres"` |
+| [`database.postgres.database`](./values.yaml#L339) | `PGDATABASE` | `"document-engine"` |
+| [`database.postgres.externalAdminSecretName`](./values.yaml#L360) | External secret for administrative database credentials, used for migrations: `PG_ADMIN_USER` and `PG_ADMIN_PASSWORD` | `""` |
+| [`database.postgres.externalSecretName`](./values.yaml#L356) | Use external secret for database credentials. `PGUSER` and `PGPASSWORD` must be provided and, if not defined: `PGDATABASE`, `PGHOST`, `PGPORT`, `PGSSL` | `""` |
+| [`database.postgres.host`](./values.yaml#L333) | `PGHOST`, if not set, and `cloudNativePG.enabled`, will rely on the Cluster | `""` |
+| [`database.postgres.password`](./values.yaml#L345) | `PGPASSWORD` | `"despair"` |
+| [`database.postgres.port`](./values.yaml#L336) | `PGPORT` | `5432` |
+| [`database.postgres.tls`](./values.yaml#L365) | TLS settings | [...](./values.yaml#L365) |
+| [`database.postgres.tls.commonName`](./values.yaml#L378) | Common name for the certificate (`PGSSL_CERT_COMMON_NAME`), defaults to `PGHOST` value | `""` |
+| [`database.postgres.tls.enabled`](./values.yaml#L368) | Enable TLS (`PGSSL`) | `false` |
+| [`database.postgres.tls.hostVerify`](./values.yaml#L374) | Negated `PGSSL_DISABLE_HOSTNAME_VERIFY` | `true` |
+| [`database.postgres.tls.trustBundle`](./values.yaml#L382) | Trust bundle for PostgreSQL, sets `PGSSL_CA_CERTS`, mutually exclusive with `trustFileName` and takes precedence | `""` |
+| [`database.postgres.tls.trustFileName`](./values.yaml#L385) | Path from `certificateTrust.customCertificates`, wraps around `PGSSL_CA_CERT_PATH` | `""` |
+| [`database.postgres.tls.verify`](./values.yaml#L371) | Negated `PGSSL_DISABLE_VERIFY` | `true` |
+| [`database.postgres.username`](./values.yaml#L342) | `PGUSER` | `"postgres"` |
 
 ### Document lifecycle
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`documentLifecycle`](./values.yaml#L309) | Document lifecycle management |  |
-| [`documentLifecycle.bulkDocumentDeletionEnabled`](./values.yaml#L312) | `ENABLE_BULK_DOCUMENT_DELETION`: enable `/api/async/delete_documents` API endpoint | `false` |
-| [`documentLifecycle.expirationJob`](./values.yaml#L316) | Regular job to remove documents from the database, requires `documentLifecycle.bulkDocumentDeletionEnabled` to be `true` | [...](./values.yaml#L316) |
-| [`documentLifecycle.expirationJob.deletionPrefix`](./values.yaml#L329) | Only delete documents with IDs beginning with this prefix. Leave empty to delete all documents matching the time filter. | `"ephemeral"` |
-| [`documentLifecycle.expirationJob.enabled`](./values.yaml#L319) | Enable the document expiration job | `false` |
-| [`documentLifecycle.expirationJob.keepHours`](./values.yaml#L325) | Documents TTL in hours | `24` |
-| [`documentLifecycle.expirationJob.schedule`](./values.yaml#L322) | Expiration job schedule in cron format | `"13 * * * *"` |
-| [`documentLifecycle.expirationJob.serviceAccountName`](./values.yaml#L340) | Service account name to specify for the expiration jobs | `""` |
+| [`documentLifecycle`](./values.yaml#L405) | Document lifecycle management |  |
+| [`documentLifecycle.bulkDocumentDeletionEnabled`](./values.yaml#L408) | `ENABLE_BULK_DOCUMENT_DELETION`: enable `/api/async/delete_documents` API endpoint | `false` |
+| [`documentLifecycle.expirationJob`](./values.yaml#L412) | Regular job to remove documents from the database, requires `documentLifecycle.bulkDocumentDeletionEnabled` to be `true` | [...](./values.yaml#L412) |
+| [`documentLifecycle.expirationJob.deletionPrefix`](./values.yaml#L425) | Only delete documents with IDs beginning with this prefix. Leave empty to delete all documents matching the time filter. | `"ephemeral"` |
+| [`documentLifecycle.expirationJob.enabled`](./values.yaml#L415) | Enable the document expiration job | `false` |
+| [`documentLifecycle.expirationJob.keepHours`](./values.yaml#L421) | Documents TTL in hours | `24` |
+| [`documentLifecycle.expirationJob.schedule`](./values.yaml#L418) | Expiration job schedule in cron format | `"13 * * * *"` |
+| [`documentLifecycle.expirationJob.serviceAccountName`](./values.yaml#L436) | Service account name to specify for the expiration jobs | `""` |
 
 ### Asset storage
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`assetStorage`](./values.yaml#L351) | Everything about storing and caching assets |  |
-| [`assetStorage.azure`](./values.yaml#L423) | Azure blob storage settings, in case `assetStorage.backendType` is set to `azure` | [...](./values.yaml#L423) |
-| [`assetStorage.azure.container`](./values.yaml#L434) | `AZURE_STORAGE_DEFAULT_CONTAINER` | `""` |
-| [`assetStorage.backendFallback`](./values.yaml#L370) | Asset storage fallback settings | [...](./values.yaml#L370) |
-| [`assetStorage.backendFallback.enabled`](./values.yaml#L373) | `ENABLE_ASSET_STORAGE_FALLBACK` | `false` |
-| [`assetStorage.backendFallback.enabledAzure`](./values.yaml#L382) | `ENABLE_ASSET_STORAGE_FALLBACK_AZURE` | `false` |
-| [`assetStorage.backendFallback.enabledPostgres`](./values.yaml#L376) | `ENABLE_ASSET_STORAGE_FALLBACK_POSTGRES` | `false` |
-| [`assetStorage.backendFallback.enabledS3`](./values.yaml#L379) | `ENABLE_ASSET_STORAGE_FALLBACK_S3` | `false` |
-| [`assetStorage.backendType`](./values.yaml#L363) | Asset storage backend is only available if `database.enabled` is `true` Sets `ASSET_STORAGE_BACKEND`: `built-in`, `s3` or `azure` | `"built-in"` |
-| [`assetStorage.fileUploadTimeoutSeconds`](./values.yaml#L366) | `FILE_UPLOAD_TIMEOUT_MS` in seconds | `30` |
-| [`assetStorage.localCacheSizeMegabytes`](./values.yaml#L355) | Sets local asset storage value in megabytes Results in `ASSET_STORAGE_CACHE_SIZE` (in bytes) | `2000` |
-| [`assetStorage.localCacheTimeoutSeconds`](./values.yaml#L359) | Sets local asset storage cache timeout in seconds Results in `ASSET_STORAGE_CACHE_TIMEOUT` (in milliseconds) | `5` |
-| [`assetStorage.redis`](./values.yaml#L452) | Redis settings for caching and prerendering | [...](./values.yaml#L452) |
-| [`assetStorage.redis.database`](./values.yaml#L470) | `REDIS_DATABASE` | `""` |
-| [`assetStorage.redis.enabled`](./values.yaml#L455) | `USE_REDIS_CACHE` | `false` |
-| [`assetStorage.redis.externalSecretName`](./values.yaml#L507) | External secret name. Must contain `REDIS_USERNAME` and `REDIS_PASSWORD` if they are needed, and _may_ set other values | `""` |
-| [`assetStorage.redis.host`](./values.yaml#L464) | `REDIS_HOST` | `"{{ .Release.Name }}-redis-master"` |
-| [`assetStorage.redis.password`](./values.yaml#L496) | `REDIS_PASSWORD` | `""` |
-| [`assetStorage.redis.port`](./values.yaml#L467) | `REDIS_PORT` | `6379` |
-| [`assetStorage.redis.sentinel`](./values.yaml#L475) | Redis Sentinel | [...](./values.yaml#L475) |
-| [`assetStorage.redis.tls`](./values.yaml#L500) | TLS settings |  |
-| [`assetStorage.redis.tls.enabled`](./values.yaml#L503) | Enable TLS (`REDIS_SSL`) | `false` |
-| [`assetStorage.redis.ttlSeconds`](./values.yaml#L461) | `REDIS_TTL` Time to live in seconds | `86400` |
-| [`assetStorage.redis.useTtl`](./values.yaml#L458) | `USE_REDIS_TTL_FOR_PRERENDERING` | `true` |
-| [`assetStorage.redis.username`](./values.yaml#L493) | `REDIS_USERNAME` | `""` |
-| [`assetStorage.s3`](./values.yaml#L386) | S3 backend storage settings, in case `assetStorage.backendType` is set to `s3 | [...](./values.yaml#L386) |
-| [`assetStorage.s3.bucket`](./values.yaml#L397) | `ASSET_STORAGE_S3_BUCKET` | `"document-engine-assets"` |
-| [`assetStorage.s3.region`](./values.yaml#L400) | `ASSET_STORAGE_S3_REGION` | `"us-east-1"` |
+| [`assetStorage`](./values.yaml#L447) | Everything about storing and caching assets |  |
+| [`assetStorage.azure`](./values.yaml#L519) | Azure blob storage settings, in case `assetStorage.backendType` is set to `azure` | [...](./values.yaml#L519) |
+| [`assetStorage.azure.container`](./values.yaml#L530) | `AZURE_STORAGE_DEFAULT_CONTAINER` | `""` |
+| [`assetStorage.backendFallback`](./values.yaml#L466) | Asset storage fallback settings | [...](./values.yaml#L466) |
+| [`assetStorage.backendFallback.enabled`](./values.yaml#L469) | `ENABLE_ASSET_STORAGE_FALLBACK` | `false` |
+| [`assetStorage.backendFallback.enabledAzure`](./values.yaml#L478) | `ENABLE_ASSET_STORAGE_FALLBACK_AZURE` | `false` |
+| [`assetStorage.backendFallback.enabledPostgres`](./values.yaml#L472) | `ENABLE_ASSET_STORAGE_FALLBACK_POSTGRES` | `false` |
+| [`assetStorage.backendFallback.enabledS3`](./values.yaml#L475) | `ENABLE_ASSET_STORAGE_FALLBACK_S3` | `false` |
+| [`assetStorage.backendType`](./values.yaml#L459) | Asset storage backend is only available if `database.enabled` is `true` Sets `ASSET_STORAGE_BACKEND`: `built-in`, `s3` or `azure` | `"built-in"` |
+| [`assetStorage.fileUploadTimeoutSeconds`](./values.yaml#L462) | `FILE_UPLOAD_TIMEOUT_MS` in seconds | `30` |
+| [`assetStorage.localCacheSizeMegabytes`](./values.yaml#L451) | Sets local asset storage value in megabytes Results in `ASSET_STORAGE_CACHE_SIZE` (in bytes) | `2000` |
+| [`assetStorage.localCacheTimeoutSeconds`](./values.yaml#L455) | Sets local asset storage cache timeout in seconds Results in `ASSET_STORAGE_CACHE_TIMEOUT` (in milliseconds) | `5` |
+| [`assetStorage.redis`](./values.yaml#L548) | Redis settings for caching and prerendering | [...](./values.yaml#L548) |
+| [`assetStorage.redis.database`](./values.yaml#L566) | `REDIS_DATABASE` | `""` |
+| [`assetStorage.redis.enabled`](./values.yaml#L551) | `USE_REDIS_CACHE` | `false` |
+| [`assetStorage.redis.externalSecretName`](./values.yaml#L603) | External secret name. Must contain `REDIS_USERNAME` and `REDIS_PASSWORD` if they are needed, and _may_ set other values | `""` |
+| [`assetStorage.redis.host`](./values.yaml#L560) | `REDIS_HOST` | `"{{ .Release.Name }}-redis-master"` |
+| [`assetStorage.redis.password`](./values.yaml#L592) | `REDIS_PASSWORD` | `""` |
+| [`assetStorage.redis.port`](./values.yaml#L563) | `REDIS_PORT` | `6379` |
+| [`assetStorage.redis.sentinel`](./values.yaml#L571) | Redis Sentinel | [...](./values.yaml#L571) |
+| [`assetStorage.redis.tls`](./values.yaml#L596) | TLS settings |  |
+| [`assetStorage.redis.tls.enabled`](./values.yaml#L599) | Enable TLS (`REDIS_SSL`) | `false` |
+| [`assetStorage.redis.ttlSeconds`](./values.yaml#L557) | `REDIS_TTL` Time to live in seconds | `86400` |
+| [`assetStorage.redis.useTtl`](./values.yaml#L554) | `USE_REDIS_TTL_FOR_PRERENDERING` | `true` |
+| [`assetStorage.redis.username`](./values.yaml#L589) | `REDIS_USERNAME` | `""` |
+| [`assetStorage.s3`](./values.yaml#L482) | S3 backend storage settings, in case `assetStorage.backendType` is set to `s3 | [...](./values.yaml#L482) |
+| [`assetStorage.s3.bucket`](./values.yaml#L493) | `ASSET_STORAGE_S3_BUCKET` | `"document-engine-assets"` |
+| [`assetStorage.s3.region`](./values.yaml#L496) | `ASSET_STORAGE_S3_REGION` | `"us-east-1"` |
 
 ### Statefulness
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`persistence`](./values.yaml#L525) | Persistent storage settings for StatefulSet pods. Only used when `workloadType` is `StatefulSet`. | [...](./values.yaml#L525) |
-| [`persistence.accessModes`](./values.yaml#L531) | PVC access modes | `["ReadWriteOnce"]` |
-| [`persistence.annotations`](./values.yaml#L541) | Annotations for each PVC | `{}` |
-| [`persistence.mountPath`](./values.yaml#L538) | Mount path inside the container | `"/srv/pspdfkit/assets"` |
-| [`persistence.selectorLabels`](./values.yaml#L544) | Selector labels for PVCs | `{}` |
-| [`persistence.size`](./values.yaml#L535) | PVC storage size | `"10Gi"` |
-| [`persistence.storageClassName`](./values.yaml#L528) | Storage class for PVCs. Empty string uses cluster default. | `"standard"` |
-| [`podManagementPolicy`](./values.yaml#L519) | Pod management policy for StatefulSet: `OrderedReady` or `Parallel`. Only used when `workloadType` is `StatefulSet`. | `"OrderedReady"` |
-| [`workloadType`](./values.yaml#L514) | Workload type: `Deployment` or `StatefulSet`. When `StatefulSet`, persistent storage is provisioned per pod via volumeClaimTemplates. **Note:** Switching an existing release from Deployment to StatefulSet requires deleting the existing Deployment first, as Kubernetes cannot change a resource kind in-place. | `"Deployment"` |
+| [`persistence`](./values.yaml#L621) | Persistent storage settings for StatefulSet pods. Only used when `workloadType` is `StatefulSet`. | [...](./values.yaml#L621) |
+| [`persistence.accessModes`](./values.yaml#L627) | PVC access modes | `["ReadWriteOnce"]` |
+| [`persistence.annotations`](./values.yaml#L637) | Annotations for each PVC | `{}` |
+| [`persistence.mountPath`](./values.yaml#L634) | Mount path inside the container | `"/srv/pspdfkit/assets"` |
+| [`persistence.selectorLabels`](./values.yaml#L640) | Selector labels for PVCs | `{}` |
+| [`persistence.size`](./values.yaml#L631) | PVC storage size | `"10Gi"` |
+| [`persistence.storageClassName`](./values.yaml#L624) | Storage class for PVCs. Empty string uses cluster default. | `"standard"` |
+| [`podManagementPolicy`](./values.yaml#L615) | Pod management policy for StatefulSet: `OrderedReady` or `Parallel`. Only used when `workloadType` is `StatefulSet`. | `"OrderedReady"` |
+| [`workloadType`](./values.yaml#L610) | Workload type: `Deployment` or `StatefulSet`. When `StatefulSet`, persistent storage is provisioned per pod via volumeClaimTemplates. **Note:** Switching an existing release from Deployment to StatefulSet requires deleting the existing Deployment first, as Kubernetes cannot change a resource kind in-place. | `"Deployment"` |
 
 ### Digital signatures
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`documentSigningService`](./values.yaml#L549) | Signing service parameters |  |
-| [`documentSigningService.cadesLevel`](./values.yaml#L575) | `DIGITAL_SIGNATURE_CADES_LEVEL` | `"b-lt"` |
-| [`documentSigningService.certificateCheckTime`](./values.yaml#L578) | `DIGITAL_SIGNATURE_CERTIFICATE_CHECK_TIME` | `"current_time"` |
-| [`documentSigningService.defaultSignatureLocation`](./values.yaml#L569) | `DEFAULT_SIGNATURE_LOCATION` | `"Head Quarters"` |
-| [`documentSigningService.defaultSignatureReason`](./values.yaml#L565) | `DEFAULT_SIGNATURE_REASON` | `"approved"` |
-| [`documentSigningService.defaultSignerName`](./values.yaml#L561) | `DEFAULT_SIGNER_NAME` | `"John Doe"` |
-| [`documentSigningService.enabled`](./values.yaml#L552) | Enable signing service integration | `false` |
-| [`documentSigningService.hashAlgorithm`](./values.yaml#L572) | `DIGITAL_SIGNATURE_HASH_ALGORITHM` | `"sha512"` |
-| [`documentSigningService.timeoutSeconds`](./values.yaml#L558) | `SIGNING_SERVICE_TIMEOUT` in seconds | `10` |
-| [`documentSigningService.timestampAuthority`](./values.yaml#L582) | Timestamp Authority (TSA) settings | [...](./values.yaml#L582) |
-| [`documentSigningService.timestampAuthority.url`](./values.yaml#L585) | `TIMESTAMP_AUTHORITY_URL` | `"https://freetsa.org/"` |
-| [`documentSigningService.url`](./values.yaml#L555) | `SIGNING_SERVICE_URL` | `"https://signing-thing.local/sign"` |
+| [`documentSigningService`](./values.yaml#L645) | Signing service parameters |  |
+| [`documentSigningService.cadesLevel`](./values.yaml#L671) | `DIGITAL_SIGNATURE_CADES_LEVEL` | `"b-lt"` |
+| [`documentSigningService.certificateCheckTime`](./values.yaml#L674) | `DIGITAL_SIGNATURE_CERTIFICATE_CHECK_TIME` | `"current_time"` |
+| [`documentSigningService.defaultSignatureLocation`](./values.yaml#L665) | `DEFAULT_SIGNATURE_LOCATION` | `"Head Quarters"` |
+| [`documentSigningService.defaultSignatureReason`](./values.yaml#L661) | `DEFAULT_SIGNATURE_REASON` | `"approved"` |
+| [`documentSigningService.defaultSignerName`](./values.yaml#L657) | `DEFAULT_SIGNER_NAME` | `"John Doe"` |
+| [`documentSigningService.enabled`](./values.yaml#L648) | Enable signing service integration | `false` |
+| [`documentSigningService.hashAlgorithm`](./values.yaml#L668) | `DIGITAL_SIGNATURE_HASH_ALGORITHM` | `"sha512"` |
+| [`documentSigningService.timeoutSeconds`](./values.yaml#L654) | `SIGNING_SERVICE_TIMEOUT` in seconds | `10` |
+| [`documentSigningService.timestampAuthority`](./values.yaml#L678) | Timestamp Authority (TSA) settings | [...](./values.yaml#L678) |
+| [`documentSigningService.timestampAuthority.url`](./values.yaml#L681) | `TIMESTAMP_AUTHORITY_URL` | `"https://freetsa.org/"` |
+| [`documentSigningService.url`](./values.yaml#L651) | `SIGNING_SERVICE_URL` | `"https://signing-thing.local/sign"` |
 
 ### Document conversion
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`documentConversion`](./values.yaml#L598) | Document conversion parameters |  |
-| [`documentConversion.spreadsheetMaxContentHeightMm`](./values.yaml#L602) | Maximal spreadsheet content height in millimetres (`SPREADSHEET_MAX_CONTENT_HEIGHT_MM`). Defaults to `0` for unlimited height. | `0` |
-| [`documentConversion.spreadsheetMaxContentWidthMm`](./values.yaml#L606) | Maximal spreadsheet content width in millimetres (`SPREADSHEET_MAX_CONTENT_WIDTH_MM`). Defaults to `0` for unlimited width. | `0` |
+| [`documentConversion`](./values.yaml#L694) | Document conversion parameters |  |
+| [`documentConversion.spreadsheetMaxContentHeightMm`](./values.yaml#L698) | Maximal spreadsheet content height in millimetres (`SPREADSHEET_MAX_CONTENT_HEIGHT_MM`). Defaults to `0` for unlimited height. | `0` |
+| [`documentConversion.spreadsheetMaxContentWidthMm`](./values.yaml#L702) | Maximal spreadsheet content width in millimetres (`SPREADSHEET_MAX_CONTENT_WIDTH_MM`). Defaults to `0` for unlimited width. | `0` |
 
 ### Clustering
 
@@ -562,192 +588,192 @@ Note:
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`clustering`](./values.yaml#L611) | Clustering settings |  |
-| [`clustering.enabled`](./values.yaml#L614) | `CLUSTERING_ENABLED`, enable clustering, only works when `replicaCount` is greater than 1 | `false` |
-| [`clustering.method`](./values.yaml#L617) | `CLUSTERING_METHOD`, only `kubernetes_dns` is currently supported | `"kubernetes_dns"` |
+| [`clustering`](./values.yaml#L707) | Clustering settings |  |
+| [`clustering.enabled`](./values.yaml#L710) | `CLUSTERING_ENABLED`, enable clustering, only works when `replicaCount` is greater than 1 | `false` |
+| [`clustering.method`](./values.yaml#L713) | `CLUSTERING_METHOD`, only `kubernetes_dns` is currently supported | `"kubernetes_dns"` |
 
 ### Dashboard
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`dashboard`](./values.yaml#L628) | Document Engine Dashboard settings |  |
-| [`dashboard.auth`](./values.yaml#L648) | Dashboard authentication | [...](./values.yaml#L648) |
-| [`dashboard.auth.externalSecret`](./values.yaml#L658) | Use an external secret for dashboard credentials | [...](./values.yaml#L658) |
-| [`dashboard.auth.externalSecret.name`](./values.yaml#L661) | External secret name | `""` |
-| [`dashboard.auth.externalSecret.passwordKey`](./values.yaml#L667) | Secret key name for the password | `"DASHBOARD_PASSWORD"` |
-| [`dashboard.auth.externalSecret.usernameKey`](./values.yaml#L664) | Secret key name for the username | `"DASHBOARD_USERNAME"` |
-| [`dashboard.auth.password`](./values.yaml#L654) | `DASHBOARD_PASSWORD` — will generate a random password if not set | `""` |
-| [`dashboard.auth.username`](./values.yaml#L651) | `DASHBOARD_USERNAME` | `"admin"` |
-| [`dashboard.enabled`](./values.yaml#L631) | Enable dashboard | `true` |
-| [`dashboard.rateLimitingEnabled`](./values.yaml#L636) | `DASHBOARD_RATE_LIMITING_ENABLED` — enables rate limiting for dashboard authentication to prevent brute force attacks. When enabled, failed authentication attempts are tracked per IP address. | `true` |
-| [`dashboard.rateLimitingMaxRequests`](./values.yaml#L640) | `DASHBOARD_RATE_LIMITING_MAX_REQUESTS` — maximum number of failed authentication attempts allowed per IP address within the time window before blocking. | `5` |
-| [`dashboard.rateLimitingWindowMs`](./values.yaml#L644) | `DASHBOARD_RATE_LIMITING_WINDOW_MS` — time window in milliseconds for tracking failed authentication attempts. After this period, the counter resets. | `60000` |
+| [`dashboard`](./values.yaml#L724) | Document Engine Dashboard settings |  |
+| [`dashboard.auth`](./values.yaml#L744) | Dashboard authentication | [...](./values.yaml#L744) |
+| [`dashboard.auth.externalSecret`](./values.yaml#L754) | Use an external secret for dashboard credentials | [...](./values.yaml#L754) |
+| [`dashboard.auth.externalSecret.name`](./values.yaml#L757) | External secret name | `""` |
+| [`dashboard.auth.externalSecret.passwordKey`](./values.yaml#L763) | Secret key name for the password | `"DASHBOARD_PASSWORD"` |
+| [`dashboard.auth.externalSecret.usernameKey`](./values.yaml#L760) | Secret key name for the username | `"DASHBOARD_USERNAME"` |
+| [`dashboard.auth.password`](./values.yaml#L750) | `DASHBOARD_PASSWORD` — will generate a random password if not set | `""` |
+| [`dashboard.auth.username`](./values.yaml#L747) | `DASHBOARD_USERNAME` | `"admin"` |
+| [`dashboard.enabled`](./values.yaml#L727) | Enable dashboard | `true` |
+| [`dashboard.rateLimitingEnabled`](./values.yaml#L732) | `DASHBOARD_RATE_LIMITING_ENABLED` — enables rate limiting for dashboard authentication to prevent brute force attacks. When enabled, failed authentication attempts are tracked per IP address. | `true` |
+| [`dashboard.rateLimitingMaxRequests`](./values.yaml#L736) | `DASHBOARD_RATE_LIMITING_MAX_REQUESTS` — maximum number of failed authentication attempts allowed per IP address within the time window before blocking. | `5` |
+| [`dashboard.rateLimitingWindowMs`](./values.yaml#L740) | `DASHBOARD_RATE_LIMITING_WINDOW_MS` — time window in milliseconds for tracking failed authentication attempts. After this period, the counter resets. | `60000` |
 
 ### Environment
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`extraEnvFrom`](./values.yaml#L862) | Extra environment variables from resources | `[]` |
-| [`extraEnvs`](./values.yaml#L859) | Extra environment variables | `[]` |
-| [`extraVolumeMounts`](./values.yaml#L868) | Additional volume mounts for Document Engine container | `[]` |
-| [`extraVolumes`](./values.yaml#L865) | Additional volumes | `[]` |
-| [`image`](./values.yaml#L819) | Image settings | [...](./values.yaml#L819) |
-| [`imagePullSecrets`](./values.yaml#L826) | Pull secrets | `[]` |
-| [`initContainers`](./values.yaml#L874) | Init containers | `[]` |
-| [`podSecurityContext`](./values.yaml#L845) | Pod security context | `{"fsGroup":999}` |
-| [`securityContext`](./values.yaml#L849) | Security context | `{}` |
-| [`serviceAccount`](./values.yaml#L838) | ServiceAccount | [...](./values.yaml#L838) |
-| [`sidecars`](./values.yaml#L871) | Additional containers | `[]` |
+| [`extraEnvFrom`](./values.yaml#L958) | Extra environment variables from resources | `[]` |
+| [`extraEnvs`](./values.yaml#L955) | Extra environment variables | `[]` |
+| [`extraVolumeMounts`](./values.yaml#L964) | Additional volume mounts for Document Engine container | `[]` |
+| [`extraVolumes`](./values.yaml#L961) | Additional volumes | `[]` |
+| [`image`](./values.yaml#L915) | Image settings | [...](./values.yaml#L915) |
+| [`imagePullSecrets`](./values.yaml#L922) | Pull secrets | `[]` |
+| [`initContainers`](./values.yaml#L970) | Init containers | `[]` |
+| [`podSecurityContext`](./values.yaml#L941) | Pod security context | `{"fsGroup":999}` |
+| [`securityContext`](./values.yaml#L945) | Security context | `{}` |
+| [`serviceAccount`](./values.yaml#L934) | ServiceAccount | [...](./values.yaml#L934) |
+| [`sidecars`](./values.yaml#L967) | Additional containers | `[]` |
 
 ### Metadata
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`deploymentAnnotations`](./values.yaml#L884) | Workload annotations (`Deployment`/`StatefulSet`) | `{}` |
-| [`deploymentExtraSelectorLabels`](./values.yaml#L889) | Additional selector labels for the workload (`Deployment`/`StatefulSet`) **Note:** Kubernetes selectors are immutable. Changing this value after first install may require recreating the workload. | `{}` |
-| [`fullnameOverride`](./values.yaml#L833) | Release full name override | `""` |
-| [`nameOverride`](./values.yaml#L830) | Release name override | `""` |
-| [`podAnnotations`](./values.yaml#L881) | Pod annotations | `{}` |
-| [`podLabels`](./values.yaml#L878) | Pod labels | `{}` |
+| [`deploymentAnnotations`](./values.yaml#L980) | Workload annotations (`Deployment`/`StatefulSet`) | `{}` |
+| [`deploymentExtraSelectorLabels`](./values.yaml#L985) | Additional selector labels for the workload (`Deployment`/`StatefulSet`) **Note:** Kubernetes selectors are immutable. Changing this value after first install may require recreating the workload. | `{}` |
+| [`fullnameOverride`](./values.yaml#L929) | Release full name override | `""` |
+| [`nameOverride`](./values.yaml#L926) | Release name override | `""` |
+| [`podAnnotations`](./values.yaml#L977) | Pod annotations | `{}` |
+| [`podLabels`](./values.yaml#L974) | Pod labels | `{}` |
 
 ### Networking
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`envoySidecar`](./values.yaml#L1058) | Envoy sidecar for consistent hashing by document ID | [...](./values.yaml#L1058) |
-| [`envoySidecar.adminPort`](./values.yaml#L1074) | Admin port for Envoy | `9901` |
-| [`envoySidecar.enabled`](./values.yaml#L1061) | Enable Envoy sidecar for consistent hashing | `false` |
-| [`envoySidecar.healthCheck`](./values.yaml#L1078) | Health check configuration for upstream cluster | [...](./values.yaml#L1078) |
-| [`envoySidecar.healthCheck.healthyThreshold`](./values.yaml#L1090) | Healthy threshold | `2` |
-| [`envoySidecar.healthCheck.interval`](./values.yaml#L1084) | Health check interval | `"10s"` |
-| [`envoySidecar.healthCheck.timeout`](./values.yaml#L1081) | Health check timeout | `"5s"` |
-| [`envoySidecar.healthCheck.unhealthyThreshold`](./values.yaml#L1087) | Unhealthy threshold | `2` |
-| [`envoySidecar.image`](./values.yaml#L1065) | Envoy sidecar image configuration | [...](./values.yaml#L1065) |
-| [`envoySidecar.port`](./values.yaml#L1071) | Port where Envoy sidecar listens | `8080` |
-| [`envoySidecar.resources`](./values.yaml#L1094) | Resource limits for Envoy sidecar | [...](./values.yaml#L1094) |
-| [`extraIngresses`](./values.yaml#L949) | Additional ingresses, e.g. for the dashboard | [...](./values.yaml#L949) |
-| [`gateway`](./values.yaml#L965) | Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) | [...](./values.yaml#L965) |
-| [`gateway.annotations`](./values.yaml#L971) | Annotations for the HTTPRoute resource | `{}` |
-| [`gateway.enabled`](./values.yaml#L968) | Enable Gateway API HTTPRoute | `false` |
-| [`gateway.extraHTTPRoutes`](./values.yaml#L1039) | Additional HTTPRoutes, e.g. for the dashboard | [...](./values.yaml#L1039) |
-| [`gateway.gateway`](./values.yaml#L1001) | Optional [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) resource. Most clusters have Gateways managed by platform teams; enable this only if you want the chart to create one. | [...](./values.yaml#L1001) |
-| [`gateway.gateway.addresses`](./values.yaml#L1034) | Gateway [addresses](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayAddress) | `[]` |
-| [`gateway.gateway.annotations`](./values.yaml#L1010) | Annotations for the Gateway resource | `{}` |
-| [`gateway.gateway.enabled`](./values.yaml#L1004) | Create a Gateway resource | `false` |
-| [`gateway.gateway.gatewayClassName`](./values.yaml#L1007) | GatewayClass name (e.g. `amazon-vpc-lattice`, or a custom ALB class) | `""` |
-| [`gateway.gateway.infrastructure`](./values.yaml#L1027) | [Infrastructure](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure) parameters, e.g. `parametersRef` for AWS Load Balancer Controller | `{}` |
-| [`gateway.gateway.labels`](./values.yaml#L1013) | Labels for the Gateway resource | `{}` |
-| [`gateway.gateway.listeners`](./values.yaml#L1016) | Gateway [listeners](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Listener) | `[]` |
-| [`gateway.hostnames`](./values.yaml#L985) | Hostnames for the HTTPRoute | `[]` |
-| [`gateway.labels`](./values.yaml#L974) | Labels for the HTTPRoute resource | `{}` |
-| [`gateway.parentRefs`](./values.yaml#L979) | References to Gateway resources this route attaches to. When `gateway.gateway.enabled` is true and this is empty, the chart-created Gateway is used automatically. See [ParentRef](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) | `[]` |
-| [`gateway.rules`](./values.yaml#L991) | HTTP routing rules. When empty, a default catch-all rule routing to the chart service is created. When rules are provided without `backendRefs`, the chart service is used as the default backend. | `[]` |
-| [`ingress`](./values.yaml#L914) | Ingress | [...](./values.yaml#L914) |
-| [`ingress.annotations`](./values.yaml#L923) | Ingress annotations | `{}` |
-| [`ingress.className`](./values.yaml#L920) | Ingress class name | `""` |
-| [`ingress.enabled`](./values.yaml#L917) | Enable ingress | `false` |
-| [`ingress.hosts`](./values.yaml#L926) | Hosts | `[]` |
-| [`ingress.tls`](./values.yaml#L940) | Ingress TLS section | `[]` |
-| [`networkPolicy`](./values.yaml#L1106) | [Network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) | [...](./values.yaml#L1106) |
-| [`networkPolicy.allowExternal`](./values.yaml#L1114) | Allow access from anywhere | `true` |
-| [`networkPolicy.allowExternalEgress`](./values.yaml#L1138) | Allow the pod to access any range of port and all destinations. | `true` |
-| [`networkPolicy.enabled`](./values.yaml#L1109) | Enable network policy | `true` |
-| [`networkPolicy.extraEgress`](./values.yaml#L1141) | Extra egress rules | `[]` |
-| [`networkPolicy.extraIngress`](./values.yaml#L1117) | Additional ingress rules | `[]` |
-| [`networkPolicy.ingressMatchSelectorLabels`](./values.yaml#L1132) | Allow traffic from other namespaces | `[]` |
-| [`service`](./values.yaml#L894) | Service | [...](./values.yaml#L894) |
-| [`service.annotations`](./values.yaml#L903) | Service annotations | `{}` |
-| [`service.internalTrafficPolicy`](./values.yaml#L906) | Service internal traffic policy | `"Cluster"` |
-| [`service.port`](./values.yaml#L900) | Service port — see also `config.port` | `5000` |
-| [`service.trafficDistribution`](./values.yaml#L909) | Service [traffic distribution policy](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) | `nil` |
-| [`service.type`](./values.yaml#L897) | Service type | `"ClusterIP"` |
+| [`envoySidecar`](./values.yaml#L1154) | Envoy sidecar for consistent hashing by document ID | [...](./values.yaml#L1154) |
+| [`envoySidecar.adminPort`](./values.yaml#L1170) | Admin port for Envoy | `9901` |
+| [`envoySidecar.enabled`](./values.yaml#L1157) | Enable Envoy sidecar for consistent hashing | `false` |
+| [`envoySidecar.healthCheck`](./values.yaml#L1174) | Health check configuration for upstream cluster | [...](./values.yaml#L1174) |
+| [`envoySidecar.healthCheck.healthyThreshold`](./values.yaml#L1186) | Healthy threshold | `2` |
+| [`envoySidecar.healthCheck.interval`](./values.yaml#L1180) | Health check interval | `"10s"` |
+| [`envoySidecar.healthCheck.timeout`](./values.yaml#L1177) | Health check timeout | `"5s"` |
+| [`envoySidecar.healthCheck.unhealthyThreshold`](./values.yaml#L1183) | Unhealthy threshold | `2` |
+| [`envoySidecar.image`](./values.yaml#L1161) | Envoy sidecar image configuration | [...](./values.yaml#L1161) |
+| [`envoySidecar.port`](./values.yaml#L1167) | Port where Envoy sidecar listens | `8080` |
+| [`envoySidecar.resources`](./values.yaml#L1190) | Resource limits for Envoy sidecar | [...](./values.yaml#L1190) |
+| [`extraIngresses`](./values.yaml#L1045) | Additional ingresses, e.g. for the dashboard | [...](./values.yaml#L1045) |
+| [`gateway`](./values.yaml#L1061) | Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) | [...](./values.yaml#L1061) |
+| [`gateway.annotations`](./values.yaml#L1067) | Annotations for the HTTPRoute resource | `{}` |
+| [`gateway.enabled`](./values.yaml#L1064) | Enable Gateway API HTTPRoute | `false` |
+| [`gateway.extraHTTPRoutes`](./values.yaml#L1135) | Additional HTTPRoutes, e.g. for the dashboard | [...](./values.yaml#L1135) |
+| [`gateway.gateway`](./values.yaml#L1097) | Optional [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway/) resource. Most clusters have Gateways managed by platform teams; enable this only if you want the chart to create one. | [...](./values.yaml#L1097) |
+| [`gateway.gateway.addresses`](./values.yaml#L1130) | Gateway [addresses](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayAddress) | `[]` |
+| [`gateway.gateway.annotations`](./values.yaml#L1106) | Annotations for the Gateway resource | `{}` |
+| [`gateway.gateway.enabled`](./values.yaml#L1100) | Create a Gateway resource | `false` |
+| [`gateway.gateway.gatewayClassName`](./values.yaml#L1103) | GatewayClass name (e.g. `amazon-vpc-lattice`, or a custom ALB class) | `""` |
+| [`gateway.gateway.infrastructure`](./values.yaml#L1123) | [Infrastructure](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayInfrastructure) parameters, e.g. `parametersRef` for AWS Load Balancer Controller | `{}` |
+| [`gateway.gateway.labels`](./values.yaml#L1109) | Labels for the Gateway resource | `{}` |
+| [`gateway.gateway.listeners`](./values.yaml#L1112) | Gateway [listeners](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Listener) | `[]` |
+| [`gateway.hostnames`](./values.yaml#L1081) | Hostnames for the HTTPRoute | `[]` |
+| [`gateway.labels`](./values.yaml#L1070) | Labels for the HTTPRoute resource | `{}` |
+| [`gateway.parentRefs`](./values.yaml#L1075) | References to Gateway resources this route attaches to. When `gateway.gateway.enabled` is true and this is empty, the chart-created Gateway is used automatically. See [ParentRef](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference) | `[]` |
+| [`gateway.rules`](./values.yaml#L1087) | HTTP routing rules. When empty, a default catch-all rule routing to the chart service is created. When rules are provided without `backendRefs`, the chart service is used as the default backend. | `[]` |
+| [`ingress`](./values.yaml#L1010) | Ingress | [...](./values.yaml#L1010) |
+| [`ingress.annotations`](./values.yaml#L1019) | Ingress annotations | `{}` |
+| [`ingress.className`](./values.yaml#L1016) | Ingress class name | `""` |
+| [`ingress.enabled`](./values.yaml#L1013) | Enable ingress | `false` |
+| [`ingress.hosts`](./values.yaml#L1022) | Hosts | `[]` |
+| [`ingress.tls`](./values.yaml#L1036) | Ingress TLS section | `[]` |
+| [`networkPolicy`](./values.yaml#L1202) | [Network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) | [...](./values.yaml#L1202) |
+| [`networkPolicy.allowExternal`](./values.yaml#L1210) | Allow access from anywhere | `true` |
+| [`networkPolicy.allowExternalEgress`](./values.yaml#L1234) | Allow the pod to access any range of port and all destinations. | `true` |
+| [`networkPolicy.enabled`](./values.yaml#L1205) | Enable network policy | `true` |
+| [`networkPolicy.extraEgress`](./values.yaml#L1237) | Extra egress rules | `[]` |
+| [`networkPolicy.extraIngress`](./values.yaml#L1213) | Additional ingress rules | `[]` |
+| [`networkPolicy.ingressMatchSelectorLabels`](./values.yaml#L1228) | Allow traffic from other namespaces | `[]` |
+| [`service`](./values.yaml#L990) | Service | [...](./values.yaml#L990) |
+| [`service.annotations`](./values.yaml#L999) | Service annotations | `{}` |
+| [`service.internalTrafficPolicy`](./values.yaml#L1002) | Service internal traffic policy | `"Cluster"` |
+| [`service.port`](./values.yaml#L996) | Service port — see also `config.port` | `5000` |
+| [`service.trafficDistribution`](./values.yaml#L1005) | Service [traffic distribution policy](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) | `nil` |
+| [`service.type`](./values.yaml#L993) | Service type | `"ClusterIP"` |
 
 ### Observability
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`observability`](./values.yaml#L672) | Observability settings |  |
-| [`observability.log`](./values.yaml#L676) | Logs | [...](./values.yaml#L676) |
-| [`observability.log.healthcheckLevel`](./values.yaml#L691) | `HEALTHCHECK_LOGLEVEL` — log level for health checks | `"debug"` |
-| [`observability.log.level`](./values.yaml#L679) | `LOG_LEVEL` | `"info"` |
-| [`observability.log.structured`](./values.yaml#L682) | `LOG_STRUCTURED` — enable structured logging in JSON format | `false` |
-| [`observability.log.structuredFlatten`](./values.yaml#L688) | `LOG_STRUCTURED_FLATTEN` — when structured logging is enabled, emit `meta`, `location`, `exception`, and `extra` fields as top-level dotted fields (e.g. `meta.event`, `location.file`) instead of nested JSON. Useful for OpenTelemetry collector pipelines and log backends that index top-level attributes. Only applies when `observability.log.structured` is `true`. | `true` |
-| [`observability.metrics`](./values.yaml#L726) | Metrics configuration | [...](./values.yaml#L726) |
-| [`observability.metrics.customTags`](./values.yaml#L732) | Global metrics tags for all exporters: `METRICS_CUSTOM_TAGS` | *generated* |
-| [`observability.metrics.grafanaDashboard`](./values.yaml#L774) | Grafana dashboard | [...](./values.yaml#L774) |
-| [`observability.metrics.grafanaDashboard.configMap`](./values.yaml#L782) | ConfigMap parameters | [...](./values.yaml#L782) |
-| [`observability.metrics.grafanaDashboard.configMap.labels`](./values.yaml#L785) | ConfigMap labels | `{"grafana_dashboard":"1"}` |
-| [`observability.metrics.grafanaDashboard.enabled`](./values.yaml#L778) | Enable Grafana dashboard. To work, requires Prometheus metrics enabled in `observability.metrics.prometheusEndpoint.enabled` | `false` |
-| [`observability.metrics.grafanaDashboard.tags`](./values.yaml#L795) | Dashboard tags | `["Nutrient","document-engine"]` |
-| [`observability.metrics.grafanaDashboard.title`](./values.yaml#L792) | Dashboard title | *generated* |
-| [`observability.metrics.prometheusEndpoint`](./values.yaml#L736) | Prometheus metrics endpoint settings | [...](./values.yaml#L736) |
-| [`observability.metrics.prometheusEndpoint.enabled`](./values.yaml#L739) | Enable Prometheus metrics endpoint, `ENABLE_PROMETHEUS` | `false` |
-| [`observability.metrics.prometheusEndpoint.port`](./values.yaml#L742) | Port for the Prometheus metrics endpoint, `PROMETHEUS_PORT` | `10254` |
-| [`observability.metrics.prometheusRule`](./values.yaml#L766) | Prometheus [PrometheusRule](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule) Requires `observability.metrics.prometheusEndpoint.enabled` to be `true` | [...](./values.yaml#L766) |
-| [`observability.metrics.serviceMonitor`](./values.yaml#L751) | Prometheus [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) Requires `observability.metrics.prometheusEndpoint.enabled` to be `true` | [...](./values.yaml#L751) |
-| [`observability.metrics.statsd`](./values.yaml#L801) | StatsD parameters | [...](./values.yaml#L801) |
-| [`observability.metrics.statsd.customTags`](./values.yaml#L814) | StatsD custom tags, `STATSD_CUSTOM_TAGS` | `` |
-| [`observability.metrics.statsd.port`](./values.yaml#L810) | StatsD port, `STATSD_PORT` | `9125` |
-| [`observability.opentelemetry`](./values.yaml#L695) | OpenTelemetry settings | [...](./values.yaml#L695) |
-| [`observability.opentelemetry.enabled`](./values.yaml#L698) | Enable OpenTelemetry (`ENABLE_OPENTELEMETRY`), only tracing is currently supported | `false` |
-| [`observability.opentelemetry.otelPropagators`](./values.yaml#L714) | `OTEL_PROPAGATORS`, propagators | `""` |
-| [`observability.opentelemetry.otelResourceAttributes`](./values.yaml#L711) | `OTEL_RESOURCE_ATTRIBUTES`, resource attributes | `""` |
-| [`observability.opentelemetry.otelServiceName`](./values.yaml#L708) | `OTEL_SERVICE_NAME`, service name | `""` |
-| [`observability.opentelemetry.otelTracesSampler`](./values.yaml#L719) | `OTEL_TRACES_SAMPLER`, should normally not be touched to allow custom `parent_based` work, but something like `parentbased_traceidratio` may be considered | `""` |
-| [`observability.opentelemetry.otelTracesSamplerArg`](./values.yaml#L722) | `OTEL_TRACES_SAMPLER_ARG`, argument for the sampler | `""` |
-| [`observability.opentelemetry.otlpExporterEndpoint`](./values.yaml#L702) | https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ `OTEL_EXPORTER_OTLP_ENDPOINT`, if not set, defaults to `http://localhost:4317` | `""` |
-| [`observability.opentelemetry.otlpExporterProtocol`](./values.yaml#L705) | `OTEL_EXPORTER_OTLP_PROTOCOL`, if not set, defaults to `grpc` | `""` |
+| [`observability`](./values.yaml#L768) | Observability settings |  |
+| [`observability.log`](./values.yaml#L772) | Logs | [...](./values.yaml#L772) |
+| [`observability.log.healthcheckLevel`](./values.yaml#L787) | `HEALTHCHECK_LOGLEVEL` — log level for health checks | `"debug"` |
+| [`observability.log.level`](./values.yaml#L775) | `LOG_LEVEL` | `"info"` |
+| [`observability.log.structured`](./values.yaml#L778) | `LOG_STRUCTURED` — enable structured logging in JSON format | `false` |
+| [`observability.log.structuredFlatten`](./values.yaml#L784) | `LOG_STRUCTURED_FLATTEN` — when structured logging is enabled, emit `meta`, `location`, `exception`, and `extra` fields as top-level dotted fields (e.g. `meta.event`, `location.file`) instead of nested JSON. Useful for OpenTelemetry collector pipelines and log backends that index top-level attributes. Only applies when `observability.log.structured` is `true`. | `true` |
+| [`observability.metrics`](./values.yaml#L822) | Metrics configuration | [...](./values.yaml#L822) |
+| [`observability.metrics.customTags`](./values.yaml#L828) | Global metrics tags for all exporters: `METRICS_CUSTOM_TAGS` | *generated* |
+| [`observability.metrics.grafanaDashboard`](./values.yaml#L870) | Grafana dashboard | [...](./values.yaml#L870) |
+| [`observability.metrics.grafanaDashboard.configMap`](./values.yaml#L878) | ConfigMap parameters | [...](./values.yaml#L878) |
+| [`observability.metrics.grafanaDashboard.configMap.labels`](./values.yaml#L881) | ConfigMap labels | `{"grafana_dashboard":"1"}` |
+| [`observability.metrics.grafanaDashboard.enabled`](./values.yaml#L874) | Enable Grafana dashboard. To work, requires Prometheus metrics enabled in `observability.metrics.prometheusEndpoint.enabled` | `false` |
+| [`observability.metrics.grafanaDashboard.tags`](./values.yaml#L891) | Dashboard tags | `["Nutrient","document-engine"]` |
+| [`observability.metrics.grafanaDashboard.title`](./values.yaml#L888) | Dashboard title | *generated* |
+| [`observability.metrics.prometheusEndpoint`](./values.yaml#L832) | Prometheus metrics endpoint settings | [...](./values.yaml#L832) |
+| [`observability.metrics.prometheusEndpoint.enabled`](./values.yaml#L835) | Enable Prometheus metrics endpoint, `ENABLE_PROMETHEUS` | `false` |
+| [`observability.metrics.prometheusEndpoint.port`](./values.yaml#L838) | Port for the Prometheus metrics endpoint, `PROMETHEUS_PORT` | `10254` |
+| [`observability.metrics.prometheusRule`](./values.yaml#L862) | Prometheus [PrometheusRule](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule) Requires `observability.metrics.prometheusEndpoint.enabled` to be `true` | [...](./values.yaml#L862) |
+| [`observability.metrics.serviceMonitor`](./values.yaml#L847) | Prometheus [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) Requires `observability.metrics.prometheusEndpoint.enabled` to be `true` | [...](./values.yaml#L847) |
+| [`observability.metrics.statsd`](./values.yaml#L897) | StatsD parameters | [...](./values.yaml#L897) |
+| [`observability.metrics.statsd.customTags`](./values.yaml#L910) | StatsD custom tags, `STATSD_CUSTOM_TAGS` | `` |
+| [`observability.metrics.statsd.port`](./values.yaml#L906) | StatsD port, `STATSD_PORT` | `9125` |
+| [`observability.opentelemetry`](./values.yaml#L791) | OpenTelemetry settings | [...](./values.yaml#L791) |
+| [`observability.opentelemetry.enabled`](./values.yaml#L794) | Enable OpenTelemetry (`ENABLE_OPENTELEMETRY`), only tracing is currently supported | `false` |
+| [`observability.opentelemetry.otelPropagators`](./values.yaml#L810) | `OTEL_PROPAGATORS`, propagators | `""` |
+| [`observability.opentelemetry.otelResourceAttributes`](./values.yaml#L807) | `OTEL_RESOURCE_ATTRIBUTES`, resource attributes | `""` |
+| [`observability.opentelemetry.otelServiceName`](./values.yaml#L804) | `OTEL_SERVICE_NAME`, service name | `""` |
+| [`observability.opentelemetry.otelTracesSampler`](./values.yaml#L815) | `OTEL_TRACES_SAMPLER`, should normally not be touched to allow custom `parent_based` work, but something like `parentbased_traceidratio` may be considered | `""` |
+| [`observability.opentelemetry.otelTracesSamplerArg`](./values.yaml#L818) | `OTEL_TRACES_SAMPLER_ARG`, argument for the sampler | `""` |
+| [`observability.opentelemetry.otlpExporterEndpoint`](./values.yaml#L798) | https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ `OTEL_EXPORTER_OTLP_ENDPOINT`, if not set, defaults to `http://localhost:4317` | `""` |
+| [`observability.opentelemetry.otlpExporterProtocol`](./values.yaml#L801) | `OTEL_EXPORTER_OTLP_PROTOCOL`, if not set, defaults to `grpc` | `""` |
 
 ### Pod lifecycle
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`lifecycle`](./values.yaml#L1201) | [Lifecycle](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) | `map[]` |
-| [`livenessProbe`](./values.yaml#L1171) | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1171) |
-| [`readinessProbe`](./values.yaml#L1184) | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1184) |
-| [`startupProbe`](./values.yaml#L1158) | [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1158) |
-| [`terminationGracePeriodSeconds`](./values.yaml#L1197) | [Termination grace period](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/). Should be greater than the longest expected request processing time (`config.requestTimeoutSeconds`). | `65` |
+| [`lifecycle`](./values.yaml#L1297) | [Lifecycle](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) | `map[]` |
+| [`livenessProbe`](./values.yaml#L1267) | [Liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1267) |
+| [`readinessProbe`](./values.yaml#L1280) | [Readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1280) |
+| [`startupProbe`](./values.yaml#L1254) | [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) | [...](./values.yaml#L1254) |
+| [`terminationGracePeriodSeconds`](./values.yaml#L1293) | [Termination grace period](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/). Should be greater than the longest expected request processing time (`config.requestTimeoutSeconds`). | `65` |
 
 ### Scheduling
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`affinity`](./values.yaml#L1256) | Node affinity | `{}` |
-| [`autoscaling`](./values.yaml#L1209) | [Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | [...](./values.yaml#L1209) |
-| [`nodeSelector`](./values.yaml#L1253) | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) | `{}` |
-| [`podDisruptionBudget`](./values.yaml#L1246) | [Pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) | [...](./values.yaml#L1246) |
-| [`priorityClassName`](./values.yaml#L1265) | [Priority classs](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) | `""` |
-| [`replicaCount`](./values.yaml#L1234) | Number of replicas | `1` |
-| [`resources`](./values.yaml#L1231) | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | `{}` |
-| [`schedulerName`](./values.yaml#L1268) | [Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) | `""` |
-| [`tolerations`](./values.yaml#L1259) | [Node tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[]` |
-| [`topologySpreadConstraints`](./values.yaml#L1262) | [Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) | `[]` |
-| [`updateStrategy`](./values.yaml#L1237) | [Update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | `{"rollingUpdate":{},"type":"RollingUpdate"}` |
+| [`affinity`](./values.yaml#L1352) | Node affinity | `{}` |
+| [`autoscaling`](./values.yaml#L1305) | [Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | [...](./values.yaml#L1305) |
+| [`nodeSelector`](./values.yaml#L1349) | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) | `{}` |
+| [`podDisruptionBudget`](./values.yaml#L1342) | [Pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) | [...](./values.yaml#L1342) |
+| [`priorityClassName`](./values.yaml#L1361) | [Priority classs](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) | `""` |
+| [`replicaCount`](./values.yaml#L1330) | Number of replicas | `1` |
+| [`resources`](./values.yaml#L1327) | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | `{}` |
+| [`schedulerName`](./values.yaml#L1364) | [Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) | `""` |
+| [`tolerations`](./values.yaml#L1355) | [Node tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[]` |
+| [`topologySpreadConstraints`](./values.yaml#L1358) | [Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) | `[]` |
+| [`updateStrategy`](./values.yaml#L1333) | [Update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) | `{"rollingUpdate":{},"type":"RollingUpdate"}` |
 
 ### Storage resource definitions
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`cloudNativePG`](./values.yaml#L1273) | [CloudNativePG](https://cloudnative-pg.io/) resources | [...](./values.yaml#L1273) |
-| [`cloudNativePG.clusterAnnotations`](./values.yaml#L1308) | Cluster annotations | `{}` |
-| [`cloudNativePG.clusterLabels`](./values.yaml#L1305) | Cluster labels | `{}` |
-| [`cloudNativePG.clusterName`](./values.yaml#L1285) | CloudNativePG custom Cluster name | `"{{ .Release.Name }}-postgres"` |
-| [`cloudNativePG.clusterSpec`](./values.yaml#L1289) | CloudNativePG [cluster spec](https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-ClusterSpec) | [...](./values.yaml#L1289) |
-| [`cloudNativePG.enabled`](./values.yaml#L1276) | Enable CloudNativePG resources | `false` |
-| [`cloudNativePG.networkPolicy`](./values.yaml#L1317) | Network policy to allow access to the cluster | `{"enabled":true}` |
-| [`cloudNativePG.operatorNamespace`](./values.yaml#L1279) | CloudNativePG operator namespace | `"cnpg-system"` |
-| [`cloudNativePG.operatorReleaseName`](./values.yaml#L1282) | CloudNativePG operator release name | `"cloudnative-pg"` |
-| [`cloudNativePG.superuserSecret`](./values.yaml#L1311) | Superuser secret to use with the cluster | `{"create":true,"password":"despair","username":"postgres"}` |
+| [`cloudNativePG`](./values.yaml#L1369) | [CloudNativePG](https://cloudnative-pg.io/) resources | [...](./values.yaml#L1369) |
+| [`cloudNativePG.clusterAnnotations`](./values.yaml#L1404) | Cluster annotations | `{}` |
+| [`cloudNativePG.clusterLabels`](./values.yaml#L1401) | Cluster labels | `{}` |
+| [`cloudNativePG.clusterName`](./values.yaml#L1381) | CloudNativePG custom Cluster name | `"{{ .Release.Name }}-postgres"` |
+| [`cloudNativePG.clusterSpec`](./values.yaml#L1385) | CloudNativePG [cluster spec](https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-ClusterSpec) | [...](./values.yaml#L1385) |
+| [`cloudNativePG.enabled`](./values.yaml#L1372) | Enable CloudNativePG resources | `false` |
+| [`cloudNativePG.networkPolicy`](./values.yaml#L1413) | Network policy to allow access to the cluster | `{"enabled":true}` |
+| [`cloudNativePG.operatorNamespace`](./values.yaml#L1375) | CloudNativePG operator namespace | `"cnpg-system"` |
+| [`cloudNativePG.operatorReleaseName`](./values.yaml#L1378) | CloudNativePG operator release name | `"cloudnative-pg"` |
+| [`cloudNativePG.superuserSecret`](./values.yaml#L1407) | Superuser secret to use with the cluster | `{"create":true,"password":"despair","username":"postgres"}` |
 
 ### Other Values
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| [`config.hoard.binaryCopyEnabled`](./values.yaml#L154) | `HOARD_BINARY_COPY_ENABLED` — internal parameter, do not change unless explicitly recommended by Nutrient support. | `true` |
-| [`config.hoard.binaryCopyThreshold`](./values.yaml#L156) | `HOARD_BINARY_COPY_THRESHOLD` — internal parameter, do not change unless explicitly recommended by Nutrient support. | `2` |
-| [`config.http2SharedRendering.checkinTimeoutMilliseconds`](./values.yaml#L167) | `HTTP2_SHARED_RENDERING_PROCESS_CHECKIN_TIMEOUT` — document processing daemon checkin timeout. Do not change unless explicitly recommended by Nutrient support. | `0` |
-| [`config.http2SharedRendering.checkoutTimeoutMilliseconds`](./values.yaml#L170) | `HTTP2_SHARED_RENDERING_PROCESS_CHECKOUT_TIMEOUT` — document processing daemon checkout timeout. Do not change unless explicitly recommended by Nutrient support. | `5000` |
-| [`revisionHistoryLimit`](./values.yaml#L1241) | [Revision history limit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) | `10` |
+| [`config.hoard.binaryCopyEnabled`](./values.yaml#L250) | `HOARD_BINARY_COPY_ENABLED` — internal parameter, do not change unless explicitly recommended by Nutrient support. | `true` |
+| [`config.hoard.binaryCopyThreshold`](./values.yaml#L252) | `HOARD_BINARY_COPY_THRESHOLD` — internal parameter, do not change unless explicitly recommended by Nutrient support. | `2` |
+| [`config.http2SharedRendering.checkinTimeoutMilliseconds`](./values.yaml#L263) | `HTTP2_SHARED_RENDERING_PROCESS_CHECKIN_TIMEOUT` — document processing daemon checkin timeout. Do not change unless explicitly recommended by Nutrient support. | `0` |
+| [`config.http2SharedRendering.checkoutTimeoutMilliseconds`](./values.yaml#L266) | `HTTP2_SHARED_RENDERING_PROCESS_CHECKOUT_TIMEOUT` — document processing daemon checkout timeout. Do not change unless explicitly recommended by Nutrient support. | `5000` |
+| [`revisionHistoryLimit`](./values.yaml#L1337) | [Revision history limit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) | `10` |
 
 ## Contribution
 

--- a/charts/document-engine/templates/_pod-template.tpl
+++ b/charts/document-engine/templates/_pod-template.tpl
@@ -111,6 +111,13 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.config.asyncJobEncryption.externalSecret.name }}
+        - name: ASYNC_JOB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.config.asyncJobEncryption.externalSecret.name }}
+              key: {{ .Values.config.asyncJobEncryption.externalSecret.key }}
+      {{- end }}
       {{- if and .Values.dashboard.enabled
                  .Values.dashboard.auth.externalSecret.name}}
         - name: DASHBOARD_USERNAME

--- a/charts/document-engine/templates/configmap.yaml
+++ b/charts/document-engine/templates/configmap.yaml
@@ -19,8 +19,20 @@ data:
   PDF_GENERATION_TIMEOUT: {{ mul 1000 .Values.config.generationTimeoutSeconds | quote }}
   REMOTE_URL_FETCH_TIMEOUT: {{ mul 1000 .Values.config.urlFetchTimeoutSeconds | quote }}
   READ_ANNOTATION_BATCH_TIMEOUT: {{ mul 1000 .Values.config.readAnnotationBatchTimeoutSeconds | quote }}
+{{- with .Values.config.batchRender }}
+  BATCH_RENDER_MAX_CONCURRENCY: {{ .maxConcurrency | quote }}
+  BATCH_RENDER_MAX_PAGES: {{ .maxPages | quote }}
+  BATCH_RENDER_PAGE_TIMEOUT_MS: {{ mul 1000 .pageTimeoutSeconds | quote }}
+{{- end }}
   MAX_UPLOAD_SIZE_BYTES: {{ mul 1048576 .Values.config.maxUploadSizeMegaBytes | quote }}
   ASYNC_JOBS_TTL: {{ .Values.config.asyncJobsTtlSeconds | quote }}
+  ASYNC_JOBS_METADATA_TTL: {{ .Values.config.asyncJobsMetadataTtlSeconds | quote }}
+  ASYNC_JOB_TIMEOUT: {{ .Values.config.asyncJobTimeoutSeconds | quote }}
+  ASYNC_JOB_MAX_RETRIES: {{ .Values.config.asyncJobMaxRetries | quote }}
+  ASYNC_JOB_RETRY_BACKOFF_SECONDS: {{ .Values.config.asyncJobRetryBackoffSeconds | quote }}
+  ASYNC_ADMISSION_QUEUES: {{ .Values.config.asyncAdmissionQueues | quote }}
+  ASYNC_ADMISSION_QUEUE_LIMITS: {{ .Values.config.asyncAdmissionQueueLimits | quote }}
+  ASYNC_WORKER_QUEUES: {{ .Values.config.asyncWorkerQueues | quote }}
   ALLOW_DOCUMENT_UPLOADS: {{ .Values.config.allowDocumentUploads | quote }}
   ALLOW_REMOTE_DOCUMENTS: {{ .Values.config.allowRemoteDocuments | quote }}
   ALLOW_DOCUMENT_GENERATION: {{ .Values.config.allowDocumentGeneration | quote }}
@@ -28,6 +40,18 @@ data:
   IGNORE_INVALID_ANNOTATIONS: {{ .Values.config.ignoreInvalidAnnotations | quote }}
   AUTOMATIC_LINK_EXTRACTION: {{ .Values.config.automaticLinkExtraction | quote }}
   MIN_SEARCH_QUERY_LENGTH: {{ .Values.config.minSearchQueryLength | quote }}
+{{- with .Values.config.remoteUrlFetch }}
+  REMOTE_URL_FETCH_POLICY: {{ .policy | quote }}
+  REMOTE_URL_FETCH_ALLOWED_HOSTS: {{ .allowedHosts | quote }}
+  REMOTE_URL_FETCH_ALLOWED_CIDRS: {{ .allowedCidrs | quote }}
+  REMOTE_URL_FETCH_ALLOW_EMBEDDED_CREDENTIALS: {{ .allowEmbeddedCredentials | quote }}
+{{- end }}
+{{- with .Values.config.search }}
+  SEARCH_FTS_ENABLED: {{ .ftsEnabled | quote }}
+  SEARCH_FTS_ENRICHMENT: {{ .ftsEnrichment | quote }}
+  SEARCH_MAX_GLYPH_SIDECAR_PAGE_BYTES: {{ .maxGlyphSidecarPageBytes | int | quote }}
+  SEARCH_FTS_BUILD_ON_WRITE: {{ .ftsBuildOnWrite | quote }}
+{{- end }}
   {{- with .Values.config.tileMaxScale }}
   TILE_MAX_SCALE: {{ . | quote }}
   {{- end }}

--- a/charts/document-engine/templates/secret.yaml
+++ b/charts/document-engine/templates/secret.yaml
@@ -29,6 +29,12 @@ data:
   JWT_ALGORITHM: {{ default "none" .Values.apiAuth.jwt.algorithm | b64enc | quote }}
 {{-   end }}
 {{- end }}
+# Async job secrets
+{{- if not .Values.config.asyncJobEncryption.externalSecret.name }}
+{{- with .Values.config.asyncJobEncryption.keys }}
+  ASYNC_JOB_ENCRYPTION_KEYS: {{ . | b64enc | quote }}
+{{- end }}
+{{- end }}
 # Database secrets
 {{- if .Values.database.enabled }}
   {{- if not .Values.database.postgres.externalSecretName }}

--- a/charts/document-engine/values.schema.json
+++ b/charts/document-engine/values.schema.json
@@ -452,11 +452,72 @@
         "allowRemoteDocuments": {
           "type": "boolean"
         },
+        "asyncAdmissionQueueLimits": {
+          "type": "string"
+        },
+        "asyncAdmissionQueues": {
+          "type": "string"
+        },
+        "asyncJobEncryption": {
+          "type": "object",
+          "properties": {
+            "externalSecret": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "keys": {
+              "type": "string"
+            }
+          }
+        },
+        "asyncJobMaxRetries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asyncJobRetryBackoffSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "asyncJobTimeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "asyncJobsMetadataTtlSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
         "asyncJobsTtlSeconds": {
           "type": "integer"
         },
+        "asyncWorkerQueues": {
+          "type": "string"
+        },
         "automaticLinkExtraction": {
           "type": "boolean"
+        },
+        "batchRender": {
+          "type": "object",
+          "properties": {
+            "maxConcurrency": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxPages": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "pageTimeoutSeconds": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
         },
         "daemonReadTimeoutSeconds": {
           "type": "integer"
@@ -522,11 +583,57 @@
         "readAnnotationBatchTimeoutSeconds": {
           "type": "integer"
         },
+        "remoteUrlFetch": {
+          "type": "object",
+          "properties": {
+            "allowEmbeddedCredentials": {
+              "type": "boolean"
+            },
+            "allowedCidrs": {
+              "type": "string"
+            },
+            "allowedHosts": {
+              "type": "string"
+            },
+            "policy": {
+              "type": "string",
+              "enum": [
+                "allowlist_only",
+                "public_only",
+                "allow_private",
+                "allow_all"
+              ]
+            }
+          }
+        },
         "replaceSecretsFromEnv": {
           "type": "boolean"
         },
         "requestTimeoutSeconds": {
           "type": "integer"
+        },
+        "search": {
+          "type": "object",
+          "properties": {
+            "ftsBuildOnWrite": {
+              "type": "boolean"
+            },
+            "ftsEnabled": {
+              "type": "boolean"
+            },
+            "ftsEnrichment": {
+              "type": "string",
+              "enum": [
+                "daemon",
+                "sidecar",
+                "none"
+              ]
+            },
+            "maxGlyphSidecarPageBytes": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
         },
         "tileMaxScale": {
           "type": [

--- a/charts/document-engine/values.yaml
+++ b/charts/document-engine/values.yaml
@@ -110,12 +110,72 @@ config:
   # -- `READ_ANNOTATION_BATCH_TIMEOUT` in seconds
   # @section -- 03. Configuration options
   readAnnotationBatchTimeoutSeconds: 20
+  # -- Batch render request settings.
+  # @default -- none
+  # @notationType -- reference
+  # @section -- 03. Configuration options
+  batchRender:
+    # -- `BATCH_RENDER_MAX_CONCURRENCY`
+    # @section -- 03. Configuration options
+    maxConcurrency: 4  # @schema minimum: 1
+    # -- `BATCH_RENDER_MAX_PAGES`
+    # @section -- 03. Configuration options
+    maxPages: 500  # @schema minimum: 1
+    # -- `BATCH_RENDER_PAGE_TIMEOUT_MS` in seconds
+    # @section -- 03. Configuration options
+    pageTimeoutSeconds: 120  # @schema minimum: 1
   # -- `MAX_UPLOAD_SIZE_BYTES` in megabytes
   # @section -- 03. Configuration options
   maxUploadSizeMegaBytes: 950
   # -- `ASYNC_JOBS_TTL`
   # @section -- 03. Configuration options
   asyncJobsTtlSeconds: 172800
+  # -- `ASYNC_JOBS_METADATA_TTL` in seconds. Must be greater than or equal to `config.asyncJobsTtlSeconds`.
+  # @section -- 03. Configuration options
+  asyncJobsMetadataTtlSeconds: 604800  # @schema minimum: 1
+  # -- `ASYNC_JOB_TIMEOUT` in seconds
+  # @section -- 03. Configuration options
+  asyncJobTimeoutSeconds: 600  # @schema minimum: 1
+  # -- `ASYNC_JOB_MAX_RETRIES`
+  # @section -- 03. Configuration options
+  asyncJobMaxRetries: 2  # @schema minimum: 0
+  # -- `ASYNC_JOB_RETRY_BACKOFF_SECONDS`
+  # @section -- 03. Configuration options
+  asyncJobRetryBackoffSeconds: 15  # @schema minimum: 1
+  # -- `ASYNC_ADMISSION_QUEUES` — comma-separated async queues accepted by this node.
+  # Set to an empty string to reject async operation admission.
+  # @section -- 03. Configuration options
+  asyncAdmissionQueues: default
+  # -- `ASYNC_ADMISSION_QUEUE_LIMITS` — optional comma-separated queue limits, for example `default=100`.
+  # Missing queues are unlimited.
+  # @section -- 03. Configuration options
+  # @default -- none
+  asyncAdmissionQueueLimits: ""
+  # -- `ASYNC_WORKER_QUEUES` — comma-separated async worker queues with concurrency, for example `default=5`.
+  # Set to an empty string to make this node skip async background work.
+  # @section -- 03. Configuration options
+  asyncWorkerQueues: default=5
+  # -- (object) Async job metadata encryption settings.
+  # @section -- 03. Configuration options
+  # @default -- none
+  # @notationType -- reference
+  asyncJobEncryption:
+    # -- `ASYNC_JOB_ENCRYPTION_KEYS` — comma-separated `key_id:base64_key[:current]` entries for encrypting async job metadata.
+    # Required for async Build API requests with remote URLs or PDF passwords.
+    # @section -- 03. Configuration options
+    # @default -- none
+    keys: ""
+    # -- (object) Use an external secret for `ASYNC_JOB_ENCRYPTION_KEYS`
+    # @section -- 03. Configuration options
+    # @default -- none
+    # @notationType -- reference
+    externalSecret:
+      # -- External secret name
+      # @section -- 03. Configuration options
+      name: ""
+      # -- Secret key name for the async job encryption keyring
+      # @section -- 03. Configuration options
+      key: ASYNC_JOB_ENCRYPTION_KEYS
   # -- `ALLOW_DOCUMENT_UPLOADS`
   # @section -- 03. Configuration options
   allowDocumentUploads: true
@@ -137,6 +197,42 @@ config:
   # -- `MIN_SEARCH_QUERY_LENGTH`
   # @section -- 03. Configuration options
   minSearchQueryLength: 3
+  # -- Customer-controlled remote URL fetch policy.
+  # @default -- none
+  # @notationType -- reference
+  # @section -- 03. Configuration options
+  remoteUrlFetch:
+    # -- `REMOTE_URL_FETCH_POLICY`
+    # @section -- 03. Configuration options
+    policy: public_only  # @schema enum: [allowlist_only, public_only, allow_private, allow_all]
+    # -- `REMOTE_URL_FETCH_ALLOWED_HOSTS` — comma-separated DNS hostnames or wildcard DNS patterns.
+    # @section -- 03. Configuration options
+    # @default -- none
+    allowedHosts: ""
+    # -- `REMOTE_URL_FETCH_ALLOWED_CIDRS` — comma-separated CIDR ranges.
+    # @section -- 03. Configuration options
+    # @default -- none
+    allowedCidrs: ""
+    # -- `REMOTE_URL_FETCH_ALLOW_EMBEDDED_CREDENTIALS`
+    # @section -- 03. Configuration options
+    allowEmbeddedCredentials: false
+  # -- Full-text search settings.
+  # @default -- none
+  # @notationType -- reference
+  # @section -- 03. Configuration options
+  search:
+    # -- `SEARCH_FTS_ENABLED`
+    # @section -- 03. Configuration options
+    ftsEnabled: false
+    # -- `SEARCH_FTS_ENRICHMENT`
+    # @section -- 03. Configuration options
+    ftsEnrichment: daemon  # @schema enum: [daemon, sidecar, none]
+    # -- `SEARCH_MAX_GLYPH_SIDECAR_PAGE_BYTES`
+    # @section -- 03. Configuration options
+    maxGlyphSidecarPageBytes: 2000000  # @schema minimum: 1
+    # -- `SEARCH_FTS_BUILD_ON_WRITE`
+    # @section -- 03. Configuration options
+    ftsBuildOnWrite: false
   # -- `TILE_MAX_SCALE` — maximum allowed tile scale, calculated as requested tile size divided by actual page size.
   # Must be greater than 1. When unset, no limit is enforced.
   # @section -- 03. Configuration options


### PR DESCRIPTION
Expose the new Document Engine 1.17.0 runtime knobs in the
`document-engine` Helm chart.

## Async jobs and async `/api/build`

Added Helm values for the async jobs configuration introduced by
Document Engine:

- `config.asyncAdmissionQueues`
  -> `ASYNC_ADMISSION_QUEUES`
- `config.asyncAdmissionQueueLimits`
  -> `ASYNC_ADMISSION_QUEUE_LIMITS`
- `config.asyncWorkerQueues`
  -> `ASYNC_WORKER_QUEUES`
- `config.asyncJobTimeoutSeconds`
  -> `ASYNC_JOB_TIMEOUT`
- `config.asyncJobMaxRetries`
  -> `ASYNC_JOB_MAX_RETRIES`
- `config.asyncJobRetryBackoffSeconds`
  -> `ASYNC_JOB_RETRY_BACKOFF_SECONDS`
- `config.asyncJobsMetadataTtlSeconds`
  -> `ASYNC_JOBS_METADATA_TTL`

The existing `config.asyncJobsTtlSeconds` value continues to render
`ASYNC_JOBS_TTL`.

## Async job encryption

Added `config.asyncJobEncryption` for `ASYNC_JOB_ENCRYPTION_KEYS`,
which Document Engine requires only when async Build API requests
contain sensitive persisted metadata such as remote URLs or PDF
passwords.

The chart supports both inline and external Secret configuration:

```yaml
config:
  asyncJobEncryption:
    keys: ""
    externalSecret:
      name: ""
      key: ASYNC_JOB_ENCRYPTION_KEYS
```

When `externalSecret.name` is empty, `keys` is rendered into the
chart-owned Secret. When `externalSecret.name` is set, the pod receives
`ASYNC_JOB_ENCRYPTION_KEYS` through an explicit `secretKeyRef`, matching
existing chart patterns for keyed external Secrets.

## Batch render

Added `config.batchRender` values:

- `config.batchRender.maxConcurrency`
  -> `BATCH_RENDER_MAX_CONCURRENCY`
- `config.batchRender.maxPages`
  -> `BATCH_RENDER_MAX_PAGES`
- `config.batchRender.pageTimeoutSeconds`
  -> `BATCH_RENDER_PAGE_TIMEOUT_MS`

The timeout value is configured in seconds in Helm values and rendered
in milliseconds for Document Engine.

## Remote URL fetch policy

Added `config.remoteUrlFetch` values:

- `config.remoteUrlFetch.policy`
  -> `REMOTE_URL_FETCH_POLICY`
- `config.remoteUrlFetch.allowedHosts`
  -> `REMOTE_URL_FETCH_ALLOWED_HOSTS`
- `config.remoteUrlFetch.allowedCidrs`
  -> `REMOTE_URL_FETCH_ALLOWED_CIDRS`
- `config.remoteUrlFetch.allowEmbeddedCredentials`
  -> `REMOTE_URL_FETCH_ALLOW_EMBEDDED_CREDENTIALS`

## Full-Text search

Added `config.search` values:

- `config.search.ftsEnabled`
  -> `SEARCH_FTS_ENABLED`
- `config.search.ftsEnrichment`
  -> `SEARCH_FTS_ENRICHMENT`
- `config.search.maxGlyphSidecarPageBytes`
  -> `SEARCH_MAX_GLYPH_SIDECAR_PAGE_BYTES`
- `config.search.ftsBuildOnWrite`
  -> `SEARCH_FTS_BUILD_ON_WRITE`

`SEARCH_MAX_GLYPH_SIDECAR_PAGE_BYTES` is rendered as an integer string
to avoid scientific notation in Helm output.