### PR TITLE
Update AI Assistant to 2.3.1

### DIFF
--- a/charts/ai-assistant/CHANGELOG.md
+++ b/charts/ai-assistant/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [2.2.1 (2026-07-28)](#221-2026-07-28)
+    - [Changed](#changed-13)
   - [2.2.0 (2026-07-09)](#220-2026-07-09)
     - [Changed](#changed-12)
   - [2.1.0 (2026-06-18)](#210-2026-06-18)
@@ -34,6 +36,12 @@
     - [Changed](#changed-8)
   - [0.0.1 (2025-05-28)](#001-2025-05-28)
     - [Added](#added-3)
+
+## 2.2.1 (2026-07-28)
+
+### Changed
+
+* [AI Assistant 2.3.1](https://www.nutrient.io/guides/ai-assistant/changelog/#2.3.1)
 
 ## 2.2.0 (2026-07-09)
 

--- a/charts/ai-assistant/Chart.yaml
+++ b/charts/ai-assistant/Chart.yaml
@@ -4,8 +4,8 @@ type: application
 description: AI Assistant is a thing that assists an AI
 home: https://www.nutrient.io/guides/ai-assistant/
 icon: https://cdn.prod.website-files.com/65fdb7696055f07a05048833/66e58e33c3880ff24aa34027_nutrient-logo.png
-version: 2.2.0
-appVersion: "2.3.0"
+version: 2.2.1
+appVersion: "2.3.1"
 
 keywords:
   - nutrient

--- a/charts/ai-assistant/README.md
+++ b/charts/ai-assistant/README.md
@@ -1,6 +1,6 @@
 # AI Assistant Helm chart
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
 AI Assistant is a thing that assists an AI
 


### PR DESCRIPTION
Updates AI Assistant to [2.3.1](https://www.nutrient.io/guides/ai-assistant/changelog/#2.3.1).

### Changes

- `appVersion` → `2.3.1`
- Chart version → `2.2.1` (patch bump)
- Changelog entry added
- README and schema regenerated via `helm-docs` and `helm schema`