### PR TITLE
[PoC] Inspect OIDC claims for an external fork PR

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -37,6 +37,52 @@ jobs:
           python-version: '3.13'
           check-latest: true
 
+      # Safe fork-PR PoC: print selected OIDC claims, never the JWT itself.
+      - name: PoC — inspect fork OIDC claims
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          EXPECTED_AUDIENCE: sts.amazonaws.com
+        run: |
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+          import urllib.request
+
+          request_url = os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"]
+          separator = "&" if "?" in request_url else "?"
+          url = f"{request_url}{separator}audience={os.environ['EXPECTED_AUDIENCE']}"
+          request = urllib.request.Request(
+              url,
+              headers={
+                  "Authorization":
+                      "Bearer " + os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"]
+              },
+          )
+
+          with urllib.request.urlopen(request) as response:
+              token = json.load(response)["value"]
+
+          encoded_payload = token.split(".")[1]
+          encoded_payload += "=" * (-len(encoded_payload) % 4)
+          claims = json.loads(base64.urlsafe_b64decode(encoded_payload))
+
+          safe_keys = [
+              "iss",
+              "sub",
+              "aud",
+              "repository",
+              "repository_owner",
+              "actor",
+              "event_name",
+              "job_workflow_ref",
+              "ref",
+              "head_ref",
+              "base_ref",
+          ]
+          print(json.dumps({key: claims.get(key) for key in safe_keys}, indent=2))
+          PY
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2
 


### PR DESCRIPTION
### Before / After

Before: we do not have direct evidence showing which OIDC claims GitHub issues when this public repository runs a workflow from an external fork PR.

After: one fork-only diagnostic step requests an OIDC token and prints only selected non-secret claims. It never prints the JWT.

### Why this approach

This is the smallest test that validates the GitHub side of the trust boundary without assuming an AWS role or accessing ECR. Using the production ECR role was rejected because a successful test would grant real private-image access.

### Demo

After a maintainer approves the fork workflow if required, inspect the `PoC — inspect fork OIDC claims` step. The relevant expected values are:

```text
sub: repo:PSPDFKit/helm-charts:pull_request
aud: sts.amazonaws.com
repository: PSPDFKit/helm-charts
event_name: pull_request
```

### Out of scope

- Assuming any AWS role
- Reading or printing repository secrets
- Pulling or exposing the private Maestrod image
- Merging this diagnostic change

### How to test

1. Approve this draft PR's workflow run if GitHub requires approval.
2. Open the `Lint and Test Charts` workflow.
3. Read only the output of `PoC — inspect fork OIDC claims`.
4. Confirm no AWS credential, ECR login, or image-pull step ran.

### Manual QA steps

Confirm the log contains decoded claim fields but contains neither a three-part JWT nor AWS access credentials.

### Risks / notes

This draft PR is a temporary security diagnostic and should be closed after evidence is captured. It changes no chart files, so existing AWS/ECR steps remain skipped.
